### PR TITLE
added first draft of broker API spec

### DIFF
--- a/docs/openapi/brokerapi.yml
+++ b/docs/openapi/brokerapi.yml
@@ -7,6 +7,8 @@ paths:
   /associate:
     post:
       summary: Associate data points regarding a user
+      security: 
+      - api_key: []
       description: >-
         Used by calling systems to share associations between user attributes
         and identifiers.  For example, connecting an email address to a TRN, or
@@ -31,6 +33,8 @@ paths:
   /find:
     post:
       summary: Find associations across datasets given the input user details
+      security: 
+      - api_key: []
       description: >-
         Used to retrieve identifiers and user attributes related to the supplied
         user identifiers and user attributes.

--- a/docs/openapi/brokerapi.yml
+++ b/docs/openapi/brokerapi.yml
@@ -1,0 +1,101 @@
+swagger: "2.0"
+info:
+  description: "This is the TeacherID Broker API"
+  version: "1.0.0"
+  title: "TeacherID Broker API"
+host: "dfe-twd-ts-brokerapi"
+basePath: "/api"
+schemes:
+- "https"
+paths:
+  /associate:
+    post:
+      summary: "Associate data points regarding a user"
+      description: "Used by calling systems to share associations between user attributes and identifiers.  For example, connecting an email address to a TRN, or a NINO to a service's local identifier"
+      operationId: "associate"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Association Object"
+        required: true
+        schema:
+          $ref: "#/definitions/Association"
+      responses:
+        "405":
+          description: "Invalid input"
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Association"
+  /find:
+    post:
+      summary: "Find associations across datasets given the input user details"
+      description: "Used to retrieve identifiers and user attributes related to the supplied user identifiers and user attributes."
+      operationId: "find"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Find Object"
+        required: true
+        schema:
+          $ref: "#/definitions/Find"
+      responses:
+        "405":
+          description: "Invalid input"
+        "200":
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Association"
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+definitions:  
+  Association:
+    type: "object"
+    required:
+    - "userAttributes"
+    - "sourceSystem"
+    properties:
+      userAttributes:
+        type: "array"
+        items:
+          $ref: "#/definitions/UserAttribute"
+      sourceSystem:
+        type: "string"
+        description: "The identifier of the system making the association"
+  UserAttribute:
+    type: "object"
+    required:
+    - "type"
+    - "value"
+    properties:
+      type:
+        type: "string"
+        example: "email"
+      value:
+        type: "string"
+        description: "The value of the identifier"
+        example: "john.doe@digital.education.gov.uk"
+  Find:
+    type: "object"
+    required:
+    - "userAttributes"
+    properties:
+      userAttributes:
+        type: "array"
+        items:
+          $ref: "#/definitions/UserAttribute"
+      matchType:
+        type: "string"
+        example: "TRN,Email"
+        description: "If specified, returns only user attributes found with the specified type."

--- a/docs/openapi/brokerapi.yml
+++ b/docs/openapi/brokerapi.yml
@@ -1,101 +1,103 @@
-swagger: "2.0"
+openapi: 3.0.3
 info:
-  description: "This is the TeacherID Broker API"
-  version: "1.0.0"
-  title: "TeacherID Broker API"
-host: "dfe-twd-ts-brokerapi"
-basePath: "/api"
-schemes:
-- "https"
+  description: This is the TeacherID Broker API
+  version: 1.0.0-oas3
+  title: TeacherID Broker API
 paths:
   /associate:
     post:
-      summary: "Associate data points regarding a user"
-      description: "Used by calling systems to share associations between user attributes and identifiers.  For example, connecting an email address to a TRN, or a NINO to a service's local identifier"
-      operationId: "associate"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Association Object"
+      summary: Associate data points regarding a user
+      description: >-
+        Used by calling systems to share associations between user attributes
+        and identifiers.  For example, connecting an email address to a TRN, or
+        a NINO to a service's local identifier
+      operationId: associate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Association'
+        description: Association Object
         required: true
-        schema:
-          $ref: "#/definitions/Association"
       responses:
-        "405":
-          description: "Invalid input"
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Association"
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Association'
+        '405':
+          description: Invalid input
   /find:
     post:
-      summary: "Find associations across datasets given the input user details"
-      description: "Used to retrieve identifiers and user attributes related to the supplied user identifiers and user attributes."
-      operationId: "find"
-      consumes:
-      - "application/json"
-      produces:
-      - "application/json"
-      parameters:
-      - in: "body"
-        name: "body"
-        description: "Find Object"
+      summary: Find associations across datasets given the input user details
+      description: >-
+        Used to retrieve identifiers and user attributes related to the supplied
+        user identifiers and user attributes.
+      operationId: find
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Find'
+        description: Find Object
         required: true
-        schema:
-          $ref: "#/definitions/Find"
       responses:
-        "405":
-          description: "Invalid input"
-        "200":
-          description: "successful operation"
-          schema:
-            $ref: "#/definitions/Association"
-securityDefinitions:
-  api_key:
-    type: "apiKey"
-    name: "api_key"
-    in: "header"
-definitions:  
-  Association:
-    type: "object"
-    required:
-    - "userAttributes"
-    - "sourceSystem"
-    properties:
-      userAttributes:
-        type: "array"
-        items:
-          $ref: "#/definitions/UserAttribute"
-      sourceSystem:
-        type: "string"
-        description: "The identifier of the system making the association"
-  UserAttribute:
-    type: "object"
-    required:
-    - "type"
-    - "value"
-    properties:
-      type:
-        type: "string"
-        example: "email"
-      value:
-        type: "string"
-        description: "The value of the identifier"
-        example: "john.doe@digital.education.gov.uk"
-  Find:
-    type: "object"
-    required:
-    - "userAttributes"
-    properties:
-      userAttributes:
-        type: "array"
-        items:
-          $ref: "#/definitions/UserAttribute"
-      matchType:
-        type: "string"
-        example: "TRN,Email"
-        description: "If specified, returns only user attributes found with the specified type."
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Association'
+        '405':
+          description: Invalid input
+servers:
+  - url: https://dfe-twd-ts-brokerapi/api
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Association:
+      type: object
+      required:
+        - userAttributes
+        - sourceSystem
+      properties:
+        userAttributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserAttribute'
+        sourceSystem:
+          type: string
+          description: The identifier of the system making the association
+    UserAttribute:
+      type: object
+      required:
+        - type
+        - value
+      properties:
+        type:
+          type: string
+          example: email
+        value:
+          type: string
+          description: The value of the identifier
+          example: john.doe@digital.education.gov.uk
+    Find:
+      type: object
+      required:
+        - userAttributes
+      properties:
+        userAttributes:
+          type: array
+          items:
+            $ref: '#/components/schemas/UserAttribute'
+        matchType:
+          type: string
+          example: TRN,Email
+          description: >-
+            If specified, returns only user attributes found with the specified
+            type.

--- a/docs/openapi/brokerapi.yml
+++ b/docs/openapi/brokerapi.yml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   description: This is the TeacherID Broker API
-  version: 1.0.0-oas3
+  version: 1.0.0
   title: TeacherID Broker API
 paths:
   /associate:

--- a/docs/openapi/brokerapi.yml
+++ b/docs/openapi/brokerapi.yml
@@ -8,7 +8,7 @@ paths:
     post:
       summary: Associate data points regarding a user
       security: 
-      - api_key: []
+      - api_key: [api_key]
       description: >-
         Used by calling systems to share associations between user attributes
         and identifiers.  For example, connecting an email address to a TRN, or
@@ -34,7 +34,7 @@ paths:
     post:
       summary: Find associations across datasets given the input user details
       security: 
-      - api_key: []
+      - api_key: [api_key]
       description: >-
         Used to retrieve identifiers and user attributes related to the supplied
         user identifiers and user attributes.


### PR DESCRIPTION
# TeacherID Broker API - OpenAPI spec draft

As part of the TeacherID system, the TeacherID - Broker API is intended to be used by calling systems to query datasets in DfE to find related identifiers, so that they can use the data they already have about a user to discover other data in other services related to the same user.

There are 2 main endpoints:
1. Find
  This endpoint is used to discover other attributes related to a user, given the attributes that the caller already has.  For example, a service might query for a TRN related to an email address - or might query if we hold a NINO for a given TRN etc.
2. Associate
  This endpoint is used to allow services to share information they learn about their users with other services.  In this case, if a service learns of an association between an email address and a TRN for example, this endpoint is used to share that association, and make it available for other services.