### PR TITLE
Stripped down C4 to remove broker API

### DIFF
--- a/docs/workspace.dsl
+++ b/docs/workspace.dsl
@@ -27,6 +27,7 @@ workspace {
             findMyTrnViews = component "Web UI Views" "Views written in Ruby that deliver the UI" "Ruby"
             DQTAPIClient = component "DQT API Client" "A component that interacts with the DQT API" "Ruby"
             ZendeskClient = component "ZenDesk API Client" "A component that interacts with the ZenDesk" "Ruby"
+            Logger = component "Logger" "A component that is responsible for logging user activity on the service" "Ruby"
         }
         }
         dqt = softwareSystem "Database of Qualified Teachers (DQT)" "A system that stores and maintains records of people in education."{
@@ -60,6 +61,7 @@ workspace {
         findMyTrnModel -> emailComponent "Verifies ownership of email via"
         findMyTrnModel -> DQTAPIClient "Queries DQT via"
         findMyTrnModel -> ZendeskClient "Creates helpdesk tickets via"
+        findMyTrnModel -> Logger "Writes audit logs to"
     }
 
     views { 

--- a/docs/workspace.dsl
+++ b/docs/workspace.dsl
@@ -22,25 +22,10 @@ workspace {
         softwareSystem = softwareSystem "Teacher Identity Service" "A DfE service for users to engage with their DfE Identity"{
         webapp = container "Teacher Identity Web Application" "A web application for users to engage with their DfE Identity"{
             findMyTrnController = component "FindTrn Controller" "A controller written in Ruby that guides a user through finding their TRN" "Ruby"
-            emailComponent = component "Email verification component" "A component that proves a user has access to an email address" "Ruby"            
-            omniauthInWebApp = component "OmniAuth" "An oAuth2/OIDC client, written in Ruby." "Ruby Gem"
-            appViews = component "Web UI Views" "Views written in Ruby that deliver the UI" "Ruby"
-        }
-        identityBroker = container "Identity Data Broker" "The data store for the identity broker. Contains attributes about people for matching purposes" "Postgres/Elastic/Neo4j"{
-            tags "DataStore"
-            identityDataModel = component "Identity Data Model" "Relational data model used to represent an teachers identity"
-        }
-        identityBrokerAPI = container "Identity Data Broker API" "This API serves matching user attributes, given a set of other attributes about a user"{
-            associateController = component "Associate Controller" "A controller written in Ruby that accepts and processes incoming requests to associate data attributes with records, or other attributes." "Ruby"
-            findController = component "Find Controller" "A controller written in Ruby that accepts requests to search for user data, based on known user attributes" "Ruby"
-            databaseLayer = component "Database Layer" "A component for interacting with the data store" "Ruby"
+            findMyTrnModel = component "FindTrn Model" "Business logic at the core of the FindMyTRN service." "Ruby"
+            emailComponent = component "Email verification component" "A component that proves a user has access to an email address" "Ruby"
+            findMyTrnViews = component "Web UI Views" "Views written in Ruby that deliver the UI" "Ruby"
             DQTAPIClient = component "DQT API Client" "A component that interacts with the DQT API" "Ruby"
-        }
-        
-        govUKIntegrator = container "GOV.UK Integration Service" "A Teacher Services level integration with GOV.UK Account based on OIDC"{
-            openIdConnectServer = component "OpenID Connect Server" "An implementation of an OIDC server that is configured to federate with GOV.UK Account" "Ruby"
-            doorkeeper = component "Doorkeeper" "An oAuth2/OIDC provider, written in Ruby." "Ruby Gem"
-            omniauth = component "OmniAuth" "An oAuth2/OIDC client, written in Ruby." "Ruby Gem"
         }
         }
         dqt = softwareSystem "Database of Qualified Teachers (DQT)" "A system that stores and maintains records of people in education."{
@@ -49,37 +34,27 @@ workspace {
         }
         
         # direct users
-        intlqtsUser -> webapp "Uses"
-        engWelshQtsUser -> webapp "Uses"
-        ittCourseUser -> webapp "Uses"
-        prohibitedUser -> webapp "Uses"
-        pensionUser -> webapp "Uses"
-        npqUser -> webapp "Uses"
+        intlqtsUser -> findMyTrnController "Uses"
+        engWelshQtsUser -> findMyTrnController "Uses"
+        ittCourseUser -> findMyTrnController "Uses"
+        prohibitedUser -> findMyTrnController "Uses"
+        pensionUser -> findMyTrnController "Uses"
+        npqUser -> findMyTrnController "Uses"
 
         # delegate users
-        schoolAdminUser -> webapp "Uses on behalf of ..."
-        ittProviderUser -> webapp "Uses on behalf of ..."
-        employer -> webapp "Uses on behalf of ..."
-        sectorDeliveryOrgs -> webapp "Uses on behalf of ..."
-        sectorAssuranceBodies -> webapp "Uses on behalf of ..."
+        schoolAdminUser -> findMyTrnController "Uses on behalf of ..."
+        ittProviderUser -> findMyTrnController "Uses on behalf of ..."
+        employer -> findMyTrnController "Uses on behalf of ..."
+        sectorDeliveryOrgs -> findMyTrnController "Uses on behalf of ..."
+        sectorAssuranceBodies -> findMyTrnController "Uses on behalf of ..."
 
-        # relationships between containers/components
-        govUkAccountSSO = softwareSystem "GOV.UK Account" "A Central Government system providing SSO services to government agencies"
-        omniauthInWebApp -> openIdConnectServer "Authenticates users using"
-        openIdConnectServer -> govUkAccountSSO "Federates with"
-        openIdConnectServer -> identityBrokerAPI "Enriches token with user attributes from"
-        openIdConnectServer -> identityBrokerAPI "Updates data store with incoming attributes from GOV.UK Account"
-        databaseLayer -> identityBroker "Persists user attribute data to"
+        # relationships between containers/components        
         DQTAPIClient -> dqtAPI "Queries for user attributes using"
         dqtAPI -> dqtCRM "Makes calls to"
-        openIdConnectServer -> doorkeeper "Uses"
-        openIdConnectServer -> omniauth "Uses"
-        findMyTrnController -> emailComponent
-        findMyTrnController -> identityBrokerAPI "Retrieves user information from"
-        associateController -> databaseLayer "Writes new association data to"
-        findController -> DQTAPIClient "Queries DQT via"        
-        findController -> databaseLayer "Queries additional user attributes in"
-        findMyTrnController -> associateController "Associates TRNs with other coordinates"
+        findMyTrnController -> findMyTrnModel "Executes business logic inside"
+        findMyTrnController -> findMyTrnViews "Interacts with users using"
+        findMyTrnModel -> emailComponent "Verifies ownership of email via"
+        findMyTrnModel -> DQTAPIClient "Queries DQT via"
     }
 
     views { 

--- a/docs/workspace.dsl
+++ b/docs/workspace.dsl
@@ -26,12 +26,15 @@ workspace {
             emailComponent = component "Email verification component" "A component that proves a user has access to an email address" "Ruby"
             findMyTrnViews = component "Web UI Views" "Views written in Ruby that deliver the UI" "Ruby"
             DQTAPIClient = component "DQT API Client" "A component that interacts with the DQT API" "Ruby"
+            ZendeskClient = component "ZenDesk API Client" "A component that interacts with the ZenDesk" "Ruby"
         }
         }
         dqt = softwareSystem "Database of Qualified Teachers (DQT)" "A system that stores and maintains records of people in education."{
             dqtAPI = container "DQT API" "API offering some basic search functionality over the Database of Qualified Teachers (DQT)" "C Sharp"  
             dqtCRM = container "DQT CRM" "A Microsoft CRM Dynamics implementation that contains data on people with Qualified Teacher Status (QTS) and other attributes." "Microsoft Dynamics CRM"
         }
+
+        zendesk = softwareSystem "ZenDesk" "A SaaS Ticketing system that is used by the TRA support team." "SaaS Managed"
         
         # direct users
         intlqtsUser -> findMyTrnController "Uses"
@@ -42,11 +45,11 @@ workspace {
         npqUser -> findMyTrnController "Uses"
 
         # delegate users
-        schoolAdminUser -> findMyTrnController "Uses on behalf of ..."
-        ittProviderUser -> findMyTrnController "Uses on behalf of ..."
-        employer -> findMyTrnController "Uses on behalf of ..."
-        sectorDeliveryOrgs -> findMyTrnController "Uses on behalf of ..."
-        sectorAssuranceBodies -> findMyTrnController "Uses on behalf of ..."
+        schoolAdminUser -> findMyTrnController "Uses on behalf of"
+        ittProviderUser -> findMyTrnController "Uses on behalf of"
+        employer -> findMyTrnController "Uses on behalf of"
+        sectorDeliveryOrgs -> findMyTrnController "Uses on behalf of"
+        sectorAssuranceBodies -> findMyTrnController "Uses on behalf of"
 
         # relationships between containers/components        
         DQTAPIClient -> dqtAPI "Queries for user attributes using"
@@ -55,6 +58,7 @@ workspace {
         findMyTrnController -> findMyTrnViews "Interacts with users using"
         findMyTrnModel -> emailComponent "Verifies ownership of email via"
         findMyTrnModel -> DQTAPIClient "Queries DQT via"
+        findMyTrnModel -> ZendeskClient "Creates helpdesk tickets via"
     }
 
     views { 

--- a/docs/workspace.dsl
+++ b/docs/workspace.dsl
@@ -53,6 +53,7 @@ workspace {
 
         # relationships between containers/components        
         DQTAPIClient -> dqtAPI "Queries for user attributes using"
+        ZendeskClient -> zendesk "Creates tickets in"
         dqtAPI -> dqtCRM "Makes calls to"
         findMyTrnController -> findMyTrnModel "Executes business logic inside"
         findMyTrnController -> findMyTrnViews "Interacts with users using"

--- a/docs/workspace.json
+++ b/docs/workspace.json
@@ -3,109 +3,34 @@
   "name" : "Name",
   "description" : "Description",
   "revision" : 0,
-  "lastModifiedDate" : "2021-11-29T15:00:10Z",
+  "lastModifiedDate" : "2021-12-07T17:03:04Z",
   "lastModifiedAgent" : "structurizr-web/2544/diagram",
   "properties" : {
-    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRybk1vZGVsID0gY29tcG9uZW50ICJGaW5kVHJuIE1vZGVsIiAiQnVzaW5lc3MgbG9naWMgYXQgdGhlIGNvcmUgb2YgdGhlIEZpbmRNeVRSTiBzZXJ2aWNlLiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRyblZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgICAgIERRVEFQSUNsaWVudCA9IGNvbXBvbmVudCAiRFFUIEFQSSBDbGllbnQiICJBIGNvbXBvbmVudCB0aGF0IGludGVyYWN0cyB3aXRoIHRoZSBEUVQgQVBJIiAiUnVieSIKICAgICAgICB9CiAgICAgICAgfQogICAgICAgIGRxdCA9IHNvZnR3YXJlU3lzdGVtICJEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJBIHN5c3RlbSB0aGF0IHN0b3JlcyBhbmQgbWFpbnRhaW5zIHJlY29yZHMgb2YgcGVvcGxlIGluIGVkdWNhdGlvbi4iewogICAgICAgICAgICBkcXRBUEkgPSBjb250YWluZXIgIkRRVCBBUEkiICJBUEkgb2ZmZXJpbmcgc29tZSBiYXNpYyBzZWFyY2ggZnVuY3Rpb25hbGl0eSBvdmVyIHRoZSBEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJDIFNoYXJwIiAgCiAgICAgICAgICAgIGRxdENSTSA9IGNvbnRhaW5lciAiRFFUIENSTSIgIkEgTWljcm9zb2Z0IENSTSBEeW5hbWljcyBpbXBsZW1lbnRhdGlvbiB0aGF0IGNvbnRhaW5zIGRhdGEgb24gcGVvcGxlIHdpdGggUXVhbGlmaWVkIFRlYWNoZXIgU3RhdHVzIChRVFMpIGFuZCBvdGhlciBhdHRyaWJ1dGVzLiIgIk1pY3Jvc29mdCBEeW5hbWljcyBDUk0iCiAgICAgICAgfQogICAgICAgIAogICAgICAgICMgZGlyZWN0IHVzZXJzCiAgICAgICAgaW50bHF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBlbmdXZWxzaFF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBpdHRDb3Vyc2VVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgcHJvaGliaXRlZFVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBwZW5zaW9uVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIgogICAgICAgIG5wcVVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKCiAgICAgICAgIyBkZWxlZ2F0ZSB1c2VycwogICAgICAgIHNjaG9vbEFkbWluVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiAuLi4iCiAgICAgICAgaXR0UHJvdmlkZXJVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBlbXBsb3llciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiAuLi4iCiAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBzZWN0b3JBc3N1cmFuY2VCb2RpZXMgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YgLi4uIgoKICAgICAgICAjIHJlbGF0aW9uc2hpcHMgYmV0d2VlbiBjb250YWluZXJzL2NvbXBvbmVudHMgICAgICAgIAogICAgICAgIERRVEFQSUNsaWVudCAtPiBkcXRBUEkgIlF1ZXJpZXMgZm9yIHVzZXIgYXR0cmlidXRlcyB1c2luZyIKICAgICAgICBkcXRBUEkgLT4gZHF0Q1JNICJNYWtlcyBjYWxscyB0byIKICAgICAgICBmaW5kTXlUcm5Db250cm9sbGVyIC0+IGZpbmRNeVRybk1vZGVsICJFeGVjdXRlcyBidXNpbmVzcyBsb2dpYyBpbnNpZGUiCiAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciAtPiBmaW5kTXlUcm5WaWV3cyAiSW50ZXJhY3RzIHdpdGggdXNlcnMgdXNpbmciCiAgICAgICAgZmluZE15VHJuTW9kZWwgLT4gZW1haWxDb21wb25lbnQgIlZlcmlmaWVzIG93bmVyc2hpcCBvZiBlbWFpbCB2aWEiCiAgICAgICAgZmluZE15VHJuTW9kZWwgLT4gRFFUQVBJQ2xpZW50ICJRdWVyaWVzIERRVCB2aWEiCiAgICB9CgogICAgdmlld3MgeyAKICAgICAgICB0aGVtZSBkZWZhdWx0CiAgICB9Cn0K"
+    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRybk1vZGVsID0gY29tcG9uZW50ICJGaW5kVHJuIE1vZGVsIiAiQnVzaW5lc3MgbG9naWMgYXQgdGhlIGNvcmUgb2YgdGhlIEZpbmRNeVRSTiBzZXJ2aWNlLiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRyblZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgICAgIERRVEFQSUNsaWVudCA9IGNvbXBvbmVudCAiRFFUIEFQSSBDbGllbnQiICJBIGNvbXBvbmVudCB0aGF0IGludGVyYWN0cyB3aXRoIHRoZSBEUVQgQVBJIiAiUnVieSIKICAgICAgICAgICAgWmVuZGVza0NsaWVudCA9IGNvbXBvbmVudCAiWmVuRGVzayBBUEkgQ2xpZW50IiAiQSBjb21wb25lbnQgdGhhdCBpbnRlcmFjdHMgd2l0aCB0aGUgWmVuRGVzayIgIlJ1YnkiCiAgICAgICAgfQogICAgICAgIH0KICAgICAgICBkcXQgPSBzb2Z0d2FyZVN5c3RlbSAiRGF0YWJhc2Ugb2YgUXVhbGlmaWVkIFRlYWNoZXJzIChEUVQpIiAiQSBzeXN0ZW0gdGhhdCBzdG9yZXMgYW5kIG1haW50YWlucyByZWNvcmRzIG9mIHBlb3BsZSBpbiBlZHVjYXRpb24uInsKICAgICAgICAgICAgZHF0QVBJID0gY29udGFpbmVyICJEUVQgQVBJIiAiQVBJIG9mZmVyaW5nIHNvbWUgYmFzaWMgc2VhcmNoIGZ1bmN0aW9uYWxpdHkgb3ZlciB0aGUgRGF0YWJhc2Ugb2YgUXVhbGlmaWVkIFRlYWNoZXJzIChEUVQpIiAiQyBTaGFycCIgIAogICAgICAgICAgICBkcXRDUk0gPSBjb250YWluZXIgIkRRVCBDUk0iICJBIE1pY3Jvc29mdCBDUk0gRHluYW1pY3MgaW1wbGVtZW50YXRpb24gdGhhdCBjb250YWlucyBkYXRhIG9uIHBlb3BsZSB3aXRoIFF1YWxpZmllZCBUZWFjaGVyIFN0YXR1cyAoUVRTKSBhbmQgb3RoZXIgYXR0cmlidXRlcy4iICJNaWNyb3NvZnQgRHluYW1pY3MgQ1JNIgogICAgICAgIH0KCiAgICAgICAgemVuZGVzayA9IHNvZnR3YXJlU3lzdGVtICJaZW5EZXNrIiAiQSBTYWFTIFRpY2tldGluZyBzeXN0ZW0gdGhhdCBpcyB1c2VkIGJ5IHRoZSBUUkEgc3VwcG9ydCB0ZWFtLiIgIlNhYVMgTWFuYWdlZCIKICAgICAgICAKICAgICAgICAjIGRpcmVjdCB1c2VycwogICAgICAgIGludGxxdHNVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgZW5nV2Vsc2hRdHNVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgaXR0Q291cnNlVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIgogICAgICAgIHByb2hpYml0ZWRVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgcGVuc2lvblVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBucHFVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCgogICAgICAgICMgZGVsZWdhdGUgdXNlcnMKICAgICAgICBzY2hvb2xBZG1pblVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCiAgICAgICAgaXR0UHJvdmlkZXJVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIgogICAgICAgIGVtcGxveWVyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIgogICAgICAgIHNlY3RvckRlbGl2ZXJ5T3JncyAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiIKICAgICAgICBzZWN0b3JBc3N1cmFuY2VCb2RpZXMgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCgogICAgICAgICMgcmVsYXRpb25zaGlwcyBiZXR3ZWVuIGNvbnRhaW5lcnMvY29tcG9uZW50cyAgICAgICAgCiAgICAgICAgRFFUQVBJQ2xpZW50IC0+IGRxdEFQSSAiUXVlcmllcyBmb3IgdXNlciBhdHRyaWJ1dGVzIHVzaW5nIgogICAgICAgIFplbmRlc2tDbGllbnQgLT4gemVuZGVzayAiQ3JlYXRlcyB0aWNrZXRzIGluIgogICAgICAgIGRxdEFQSSAtPiBkcXRDUk0gIk1ha2VzIGNhbGxzIHRvIgogICAgICAgIGZpbmRNeVRybkNvbnRyb2xsZXIgLT4gZmluZE15VHJuTW9kZWwgIkV4ZWN1dGVzIGJ1c2luZXNzIGxvZ2ljIGluc2lkZSIKICAgICAgICBmaW5kTXlUcm5Db250cm9sbGVyIC0+IGZpbmRNeVRyblZpZXdzICJJbnRlcmFjdHMgd2l0aCB1c2VycyB1c2luZyIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBlbWFpbENvbXBvbmVudCAiVmVyaWZpZXMgb3duZXJzaGlwIG9mIGVtYWlsIHZpYSIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBEUVRBUElDbGllbnQgIlF1ZXJpZXMgRFFUIHZpYSIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBaZW5kZXNrQ2xpZW50ICJDcmVhdGVzIGhlbHBkZXNrIHRpY2tldHMgdmlhIgogICAgfQoKICAgIHZpZXdzIHsgCiAgICAgICAgdGhlbWUgZGVmYXVsdAogICAgfQp9Cg=="
   },
   "configuration" : { },
   "model" : {
     "people" : [ {
-      "id" : "11",
+      "id" : "6",
       "tags" : "Element,Person",
-      "name" : "Appropriate bodies- checking data",
+      "name" : "Started an NPQ",
       "relationships" : [ {
-        "id" : "54",
+        "id" : "39",
         "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "52",
-        "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "53",
-        "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "4",
-      "tags" : "Element,Person",
-      "name" : "Ex Teacher (Prohibited)",
-      "relationships" : [ {
-        "id" : "31",
-        "tags" : "Relationship",
-        "sourceId" : "4",
+        "sourceId" : "6",
         "destinationId" : "14",
         "description" : "Uses"
       }, {
-        "id" : "32",
+        "id" : "41",
         "tags" : "Relationship",
-        "sourceId" : "4",
-        "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "33",
-        "tags" : "Relationship",
-        "sourceId" : "4",
-        "destinationId" : "12",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "5",
-      "tags" : "Element,Person",
-      "name" : "Pensioner (TPS)",
-      "relationships" : [ {
-        "id" : "36",
-        "tags" : "Relationship",
-        "sourceId" : "5",
+        "sourceId" : "6",
         "destinationId" : "12",
         "description" : "Uses"
       }, {
-        "id" : "35",
+        "id" : "40",
         "tags" : "Relationship",
-        "sourceId" : "5",
+        "sourceId" : "6",
         "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "34",
-        "tags" : "Relationship",
-        "sourceId" : "5",
-        "destinationId" : "14",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "2",
-      "tags" : "Element,Person",
-      "name" : "English/Welsh QTS Holder",
-      "relationships" : [ {
-        "id" : "26",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "25",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "14",
-        "description" : "Uses"
-      }, {
-        "id" : "27",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "12",
         "description" : "Uses"
       } ],
       "group" : "Non-delegates",
@@ -118,141 +43,41 @@
         "id" : "42",
         "tags" : "Relationship",
         "sourceId" : "7",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "40",
-        "tags" : "Relationship",
-        "sourceId" : "7",
         "destinationId" : "14",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "41",
-        "tags" : "Relationship",
-        "sourceId" : "7",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "1",
-      "tags" : "Element,Person",
-      "name" : "International recognition QTS",
-      "relationships" : [ {
-        "id" : "22",
-        "tags" : "Relationship",
-        "sourceId" : "1",
-        "destinationId" : "14",
-        "description" : "Uses"
-      }, {
-        "id" : "24",
-        "tags" : "Relationship",
-        "sourceId" : "1",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "23",
-        "tags" : "Relationship",
-        "sourceId" : "1",
-        "destinationId" : "13",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "8",
-      "tags" : "Element,Person",
-      "name" : "ITT Provider",
-      "relationships" : [ {
-        "id" : "45",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "43",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of ..."
+        "description" : "Uses on behalf of"
       }, {
         "id" : "44",
         "tags" : "Relationship",
-        "sourceId" : "8",
+        "sourceId" : "7",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "43",
+        "tags" : "Relationship",
+        "sourceId" : "7",
         "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
+        "description" : "Uses on behalf of"
       } ],
       "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "10",
-      "tags" : "Element,Person",
-      "name" : "ITT, NPQ training providers (diff classes of SKITS,HEIs)",
-      "relationships" : [ {
-        "id" : "49",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "51",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "50",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "6",
-      "tags" : "Element,Person",
-      "name" : "Started an NPQ",
-      "relationships" : [ {
-        "id" : "39",
-        "tags" : "Relationship",
-        "sourceId" : "6",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "37",
-        "tags" : "Relationship",
-        "sourceId" : "6",
-        "destinationId" : "14",
-        "description" : "Uses"
-      }, {
-        "id" : "38",
-        "tags" : "Relationship",
-        "sourceId" : "6",
-        "destinationId" : "13",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
       "location" : "Unspecified"
     }, {
       "id" : "3",
       "tags" : "Element,Person",
       "name" : "Started ITT",
       "relationships" : [ {
-        "id" : "29",
+        "id" : "31",
         "tags" : "Relationship",
         "sourceId" : "3",
         "destinationId" : "13",
         "description" : "Uses"
       }, {
-        "id" : "30",
+        "id" : "32",
         "tags" : "Relationship",
         "sourceId" : "3",
         "destinationId" : "12",
         "description" : "Uses"
       }, {
-        "id" : "28",
+        "id" : "30",
         "tags" : "Relationship",
         "sourceId" : "3",
         "destinationId" : "14",
@@ -265,43 +90,250 @@
       "tags" : "Element,Person",
       "name" : "Employers (in education orgs to check status)",
       "relationships" : [ {
-        "id" : "47",
+        "id" : "49",
         "tags" : "Relationship",
         "sourceId" : "9",
         "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "46",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of ..."
+        "description" : "Uses on behalf of"
       }, {
         "id" : "48",
         "tags" : "Relationship",
         "sourceId" : "9",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "50",
+        "tags" : "Relationship",
+        "sourceId" : "9",
         "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
+        "description" : "Uses on behalf of"
       } ],
       "group" : "delegates",
       "location" : "Unspecified"
+    }, {
+      "id" : "4",
+      "tags" : "Element,Person",
+      "name" : "Ex Teacher (Prohibited)",
+      "relationships" : [ {
+        "id" : "34",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "33",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "35",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "12",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "8",
+      "tags" : "Element,Person",
+      "name" : "ITT Provider",
+      "relationships" : [ {
+        "id" : "46",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "47",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "45",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "11",
+      "tags" : "Element,Person",
+      "name" : "Appropriate bodies- checking data",
+      "relationships" : [ {
+        "id" : "55",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "56",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "54",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "10",
+      "tags" : "Element,Person",
+      "name" : "ITT, NPQ training providers (diff classes of SKITS,HEIs)",
+      "relationships" : [ {
+        "id" : "51",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "52",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "53",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "2",
+      "tags" : "Element,Person",
+      "name" : "English/Welsh QTS Holder",
+      "relationships" : [ {
+        "id" : "28",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "29",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "27",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "14",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "1",
+      "tags" : "Element,Person",
+      "name" : "International recognition QTS",
+      "relationships" : [ {
+        "id" : "26",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "25",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "24",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "14",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "5",
+      "tags" : "Element,Person",
+      "name" : "Pensioner (TPS)",
+      "relationships" : [ {
+        "id" : "38",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "36",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "37",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "13",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
     } ],
     "softwareSystems" : [ {
+      "id" : "20",
+      "tags" : "Element,Software System",
+      "name" : "Database of Qualified Teachers (DQT)",
+      "description" : "A system that stores and maintains records of people in education.",
+      "location" : "Unspecified",
+      "containers" : [ {
+        "id" : "21",
+        "tags" : "Element,Container",
+        "name" : "DQT API",
+        "description" : "API offering some basic search functionality over the Database of Qualified Teachers (DQT)",
+        "relationships" : [ {
+          "id" : "66",
+          "tags" : "Relationship",
+          "sourceId" : "21",
+          "destinationId" : "22",
+          "description" : "Makes calls to"
+        } ],
+        "technology" : "C Sharp"
+      }, {
+        "id" : "22",
+        "tags" : "Element,Container",
+        "name" : "DQT CRM",
+        "description" : "A Microsoft CRM Dynamics implementation that contains data on people with Qualified Teacher Status (QTS) and other attributes.",
+        "technology" : "Microsoft Dynamics CRM"
+      } ]
+    }, {
       "id" : "12",
       "tags" : "Element,Software System",
       "name" : "Teacher Identity Service",
       "description" : "A DfE service for users to engage with their DfE Identity",
       "relationships" : [ {
-        "id" : "59",
+        "id" : "65",
+        "tags" : "Relationship",
+        "sourceId" : "12",
+        "destinationId" : "23",
+        "description" : "Creates tickets in"
+      }, {
+        "id" : "62",
         "tags" : "Relationship",
         "sourceId" : "12",
         "destinationId" : "20",
         "description" : "Queries for user attributes using"
       }, {
-        "id" : "60",
+        "id" : "61",
         "tags" : "Relationship",
         "sourceId" : "12",
-        "destinationId" : "19",
+        "destinationId" : "21",
         "description" : "Queries for user attributes using"
       } ],
       "location" : "Unspecified",
@@ -311,42 +343,41 @@
         "name" : "Teacher Identity Web Application",
         "description" : "A web application for users to engage with their DfE Identity",
         "relationships" : [ {
-          "id" : "58",
+          "id" : "59",
           "tags" : "Relationship",
           "sourceId" : "13",
-          "destinationId" : "19",
+          "destinationId" : "21",
           "description" : "Queries for user attributes using"
         }, {
-          "id" : "57",
+          "id" : "60",
           "tags" : "Relationship",
           "sourceId" : "13",
           "destinationId" : "20",
           "description" : "Queries for user attributes using"
+        }, {
+          "id" : "64",
+          "tags" : "Relationship",
+          "sourceId" : "13",
+          "destinationId" : "23",
+          "description" : "Creates tickets in"
         } ],
         "components" : [ {
-          "id" : "16",
+          "id" : "14",
           "tags" : "Element,Component",
-          "name" : "Email verification component",
-          "description" : "A component that proves a user has access to an email address",
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "15",
-          "tags" : "Element,Component",
-          "name" : "FindTrn Model",
-          "description" : "Business logic at the core of the FindMyTRN service.",
+          "name" : "FindTrn Controller",
+          "description" : "A controller written in Ruby that guides a user through finding their TRN",
           "relationships" : [ {
-            "id" : "65",
+            "id" : "68",
             "tags" : "Relationship",
-            "sourceId" : "15",
-            "destinationId" : "18",
-            "description" : "Queries DQT via"
+            "sourceId" : "14",
+            "destinationId" : "17",
+            "description" : "Interacts with users using"
           }, {
-            "id" : "64",
+            "id" : "67",
             "tags" : "Relationship",
-            "sourceId" : "15",
-            "destinationId" : "16",
-            "description" : "Verifies ownership of email via"
+            "sourceId" : "14",
+            "destinationId" : "15",
+            "description" : "Executes business logic inside"
           } ],
           "technology" : "Ruby",
           "size" : 0
@@ -356,16 +387,16 @@
           "name" : "DQT API Client",
           "description" : "A component that interacts with the DQT API",
           "relationships" : [ {
-            "id" : "55",
+            "id" : "58",
             "tags" : "Relationship",
             "sourceId" : "18",
             "destinationId" : "20",
             "description" : "Queries for user attributes using"
           }, {
-            "id" : "56",
+            "id" : "57",
             "tags" : "Relationship",
             "sourceId" : "18",
-            "destinationId" : "19",
+            "destinationId" : "21",
             "description" : "Queries for user attributes using"
           } ],
           "technology" : "Ruby",
@@ -378,53 +409,60 @@
           "technology" : "Ruby",
           "size" : 0
         }, {
-          "id" : "14",
+          "id" : "19",
           "tags" : "Element,Component",
-          "name" : "FindTrn Controller",
-          "description" : "A controller written in Ruby that guides a user through finding their TRN",
+          "name" : "ZenDesk API Client",
+          "description" : "A component that interacts with the ZenDesk",
           "relationships" : [ {
             "id" : "63",
             "tags" : "Relationship",
-            "sourceId" : "14",
-            "destinationId" : "17",
-            "description" : "Interacts with users using"
-          }, {
-            "id" : "62",
+            "sourceId" : "19",
+            "destinationId" : "23",
+            "description" : "Creates tickets in"
+          } ],
+          "technology" : "Ruby",
+          "size" : 0
+        }, {
+          "id" : "16",
+          "tags" : "Element,Component",
+          "name" : "Email verification component",
+          "description" : "A component that proves a user has access to an email address",
+          "technology" : "Ruby",
+          "size" : 0
+        }, {
+          "id" : "15",
+          "tags" : "Element,Component",
+          "name" : "FindTrn Model",
+          "description" : "Business logic at the core of the FindMyTRN service.",
+          "relationships" : [ {
+            "id" : "70",
             "tags" : "Relationship",
-            "sourceId" : "14",
-            "destinationId" : "15",
-            "description" : "Executes business logic inside"
+            "sourceId" : "15",
+            "destinationId" : "18",
+            "description" : "Queries DQT via"
+          }, {
+            "id" : "71",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "19",
+            "description" : "Creates helpdesk tickets via"
+          }, {
+            "id" : "69",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "16",
+            "description" : "Verifies ownership of email via"
           } ],
           "technology" : "Ruby",
           "size" : 0
         } ]
       } ]
     }, {
-      "id" : "19",
-      "tags" : "Element,Software System",
-      "name" : "Database of Qualified Teachers (DQT)",
-      "description" : "A system that stores and maintains records of people in education.",
-      "location" : "Unspecified",
-      "containers" : [ {
-        "id" : "20",
-        "tags" : "Element,Container",
-        "name" : "DQT API",
-        "description" : "API offering some basic search functionality over the Database of Qualified Teachers (DQT)",
-        "relationships" : [ {
-          "id" : "61",
-          "tags" : "Relationship",
-          "sourceId" : "20",
-          "destinationId" : "21",
-          "description" : "Makes calls to"
-        } ],
-        "technology" : "C Sharp"
-      }, {
-        "id" : "21",
-        "tags" : "Element,Container",
-        "name" : "DQT CRM",
-        "description" : "A Microsoft CRM Dynamics implementation that contains data on people with Qualified Teacher Status (QTS) and other attributes.",
-        "technology" : "Microsoft Dynamics CRM"
-      } ]
+      "id" : "23",
+      "tags" : "Element,Software System,SaaS Managed",
+      "name" : "ZenDesk",
+      "description" : "A SaaS Ticketing system that is used by the TRA support team.",
+      "location" : "Unspecified"
     } ]
   },
   "documentation" : { },
@@ -454,8 +492,8 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "19",
-        "x" : 3804,
+        "id" : "23",
+        "x" : 3429,
         "y" : 1629
       }, {
         "id" : "1",
@@ -494,74 +532,80 @@
         "x" : 1029,
         "y" : 329
       }, {
+        "id" : "20",
+        "x" : 4179,
+        "y" : 1629
+      }, {
         "id" : "10",
         "x" : 329,
         "y" : 329
       } ],
       "relationships" : [ {
-        "id" : "60"
-      }, {
-        "id" : "51",
-        "vertices" : [ {
-          "x" : 879,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "42",
-        "vertices" : [ {
-          "x" : 2979,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "54",
-        "vertices" : [ {
-          "x" : 3650,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "30",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "27",
-        "vertices" : [ {
-          "x" : 6479,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "36"
-      }, {
-        "id" : "24",
-        "vertices" : [ {
-          "x" : 7179,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "33",
-        "vertices" : [ {
-          "x" : 5079,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "45",
-        "vertices" : [ {
-          "x" : 2279,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "48",
+        "id" : "50",
         "vertices" : [ {
           "x" : 1579,
           "y" : 833
         } ]
       }, {
-        "id" : "39"
+        "id" : "62"
+      }, {
+        "id" : "41"
+      }, {
+        "id" : "65"
+      }, {
+        "id" : "53",
+        "vertices" : [ {
+          "x" : 879,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "32",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "29",
+        "vertices" : [ {
+          "x" : 6479,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "26",
+        "vertices" : [ {
+          "x" : 7179,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "35",
+        "vertices" : [ {
+          "x" : 5079,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "44",
+        "vertices" : [ {
+          "x" : 2979,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "56",
+        "vertices" : [ {
+          "x" : 3650,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "47",
+        "vertices" : [ {
+          "x" : 2279,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "38"
       } ]
     } ],
     "systemContextViews" : [ {
-      "softwareSystemId" : "19",
+      "softwareSystemId" : "20",
       "key" : "DatabaseofQualifiedTeachersDQT-SystemContext",
       "paperSize" : "A6_Portrait",
       "dimensions" : {
@@ -582,12 +626,41 @@
         "x" : 208,
         "y" : 208
       }, {
-        "id" : "19",
+        "id" : "20",
         "x" : 208,
         "y" : 808
       } ],
       "relationships" : [ {
-        "id" : "60"
+        "id" : "62"
+      } ]
+    }, {
+      "softwareSystemId" : "23",
+      "key" : "ZenDesk-SystemContext",
+      "paperSize" : "A6_Portrait",
+      "dimensions" : {
+        "width" : 866,
+        "height" : 1316
+      },
+      "automaticLayout" : {
+        "implementation" : "Graphviz",
+        "rankDirection" : "TopBottom",
+        "rankSeparation" : 300,
+        "nodeSeparation" : 300,
+        "edgeSeparation" : 0,
+        "vertices" : false
+      },
+      "enterpriseBoundaryVisible" : true,
+      "elements" : [ {
+        "id" : "23",
+        "x" : 208,
+        "y" : 808
+      }, {
+        "id" : "12",
+        "x" : 208,
+        "y" : 208
+      } ],
+      "relationships" : [ {
+        "id" : "65"
       } ]
     }, {
       "softwareSystemId" : "12",
@@ -615,8 +688,8 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "19",
-        "x" : 3804,
+        "id" : "23",
+        "x" : 3429,
         "y" : 1629
       }, {
         "id" : "1",
@@ -655,74 +728,80 @@
         "x" : 1029,
         "y" : 329
       }, {
+        "id" : "20",
+        "x" : 4179,
+        "y" : 1629
+      }, {
         "id" : "10",
         "x" : 329,
         "y" : 329
       } ],
       "relationships" : [ {
-        "id" : "60"
-      }, {
-        "id" : "51",
-        "vertices" : [ {
-          "x" : 879,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "42",
-        "vertices" : [ {
-          "x" : 2979,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "54",
-        "vertices" : [ {
-          "x" : 3650,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "30",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "27",
-        "vertices" : [ {
-          "x" : 6479,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "36"
-      }, {
-        "id" : "24",
-        "vertices" : [ {
-          "x" : 7179,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "33",
-        "vertices" : [ {
-          "x" : 5079,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "45",
-        "vertices" : [ {
-          "x" : 2279,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "48",
+        "id" : "50",
         "vertices" : [ {
           "x" : 1579,
           "y" : 833
         } ]
       }, {
-        "id" : "39"
+        "id" : "41"
+      }, {
+        "id" : "62"
+      }, {
+        "id" : "53",
+        "vertices" : [ {
+          "x" : 879,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "65"
+      }, {
+        "id" : "32",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "29",
+        "vertices" : [ {
+          "x" : 6479,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "26",
+        "vertices" : [ {
+          "x" : 7179,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "35",
+        "vertices" : [ {
+          "x" : 5079,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "44",
+        "vertices" : [ {
+          "x" : 2979,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "56",
+        "vertices" : [ {
+          "x" : 3650,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "47",
+        "vertices" : [ {
+          "x" : 2279,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "38"
       } ]
     } ],
     "containerViews" : [ {
-      "softwareSystemId" : "19",
+      "softwareSystemId" : "20",
       "key" : "DatabaseofQualifiedTeachersDQT-Container",
       "paperSize" : "A5_Portrait",
       "dimensions" : {
@@ -739,22 +818,22 @@
       },
       "externalSoftwareSystemBoundariesVisible" : true,
       "elements" : [ {
+        "id" : "22",
+        "x" : 329,
+        "y" : 1408
+      }, {
         "id" : "12",
         "x" : 329,
         "y" : 208
       }, {
-        "id" : "20",
-        "x" : 329,
-        "y" : 808
-      }, {
         "id" : "21",
         "x" : 329,
-        "y" : 1408
+        "y" : 808
       } ],
       "relationships" : [ {
         "id" : "61"
       }, {
-        "id" : "59"
+        "id" : "66"
       } ]
     }, {
       "softwareSystemId" : "12",
@@ -778,13 +857,13 @@
         "x" : 208,
         "y" : 208
       }, {
+        "id" : "23",
+        "x" : 3308,
+        "y" : 1508
+      }, {
         "id" : "13",
         "x" : 3683,
         "y" : 908
-      }, {
-        "id" : "19",
-        "x" : 3683,
-        "y" : 1508
       }, {
         "id" : "1",
         "x" : 908,
@@ -822,66 +901,72 @@
         "x" : 6508,
         "y" : 208
       }, {
+        "id" : "20",
+        "x" : 4058,
+        "y" : 1508
+      }, {
         "id" : "10",
         "x" : 7208,
         "y" : 208
       } ],
       "relationships" : [ {
-        "id" : "50",
+        "id" : "60"
+      }, {
+        "id" : "40"
+      }, {
+        "id" : "52",
         "vertices" : [ {
           "x" : 7058,
           "y" : 608
         } ]
       }, {
-        "id" : "41",
+        "id" : "43",
         "vertices" : [ {
           "x" : 4958,
           "y" : 608
         } ]
       }, {
-        "id" : "53",
-        "vertices" : [ {
-          "x" : 758,
-          "y" : 608
-        } ]
+        "id" : "64"
       }, {
-        "id" : "32"
-      }, {
-        "id" : "29",
+        "id" : "31",
         "vertices" : [ {
           "x" : 2858,
           "y" : 608
         } ]
       }, {
-        "id" : "26",
+        "id" : "28",
         "vertices" : [ {
           "x" : 2158,
           "y" : 608
         } ]
       }, {
-        "id" : "35"
+        "id" : "37"
       }, {
-        "id" : "23",
+        "id" : "25",
         "vertices" : [ {
           "x" : 1458,
           "y" : 608
         } ]
       }, {
-        "id" : "44",
+        "id" : "34"
+      }, {
+        "id" : "55",
+        "vertices" : [ {
+          "x" : 758,
+          "y" : 608
+        } ]
+      }, {
+        "id" : "46",
         "vertices" : [ {
           "x" : 5658,
           "y" : 608
         } ]
       }, {
-        "id" : "47",
+        "id" : "49",
         "vertices" : [ {
           "x" : 6358,
           "y" : 608
         } ]
-      }, {
-        "id" : "58"
-      }, {
-        "id" : "38"
       } ]
     } ],
     "componentViews" : [ {
@@ -906,6 +991,10 @@
         "x" : 207,
         "y" : 207
       }, {
+        "id" : "23",
+        "x" : 4057,
+        "y" : 2707
+      }, {
         "id" : "14",
         "x" : 3682,
         "y" : 907
@@ -915,7 +1004,7 @@
         "y" : 1507
       }, {
         "id" : "16",
-        "x" : 3307,
+        "x" : 2557,
         "y" : 2107
       }, {
         "id" : "17",
@@ -923,12 +1012,12 @@
         "y" : 1507
       }, {
         "id" : "18",
-        "x" : 4057,
+        "x" : 3307,
         "y" : 2107
       }, {
         "id" : "19",
         "x" : 4057,
-        "y" : 2707
+        "y" : 2107
       }, {
         "id" : "1",
         "x" : 907,
@@ -966,74 +1055,82 @@
         "x" : 6507,
         "y" : 207
       }, {
+        "id" : "20",
+        "x" : 3307,
+        "y" : 2707
+      }, {
         "id" : "10",
         "x" : 7207,
         "y" : 207
       } ],
       "relationships" : [ {
+        "id" : "70"
+      }, {
+        "id" : "71"
+      }, {
         "id" : "63"
       }, {
-        "id" : "40",
+        "id" : "51",
+        "vertices" : [ {
+          "x" : 7057,
+          "y" : 607
+        } ]
+      }, {
+        "id" : "42",
         "vertices" : [ {
           "x" : 4957,
           "y" : 607
         } ]
       }, {
-        "id" : "62"
-      }, {
-        "id" : "52",
+        "id" : "54",
         "vertices" : [ {
           "x" : 757,
           "y" : 607
         } ]
       }, {
-        "id" : "65"
-      }, {
-        "id" : "64"
-      }, {
-        "id" : "43",
-        "vertices" : [ {
-          "x" : 5657,
-          "y" : 607
-        } ]
-      }, {
-        "id" : "31"
-      }, {
-        "id" : "28",
+        "id" : "30",
         "vertices" : [ {
           "x" : 2857,
           "y" : 607
         } ]
       }, {
-        "id" : "37"
-      }, {
-        "id" : "25",
+        "id" : "27",
         "vertices" : [ {
           "x" : 2157,
           "y" : 607
         } ]
       }, {
-        "id" : "34"
+        "id" : "36"
       }, {
-        "id" : "22",
+        "id" : "24",
         "vertices" : [ {
           "x" : 1457,
           "y" : 607
         } ]
       }, {
-        "id" : "56"
+        "id" : "33"
       }, {
-        "id" : "46",
+        "id" : "67"
+      }, {
+        "id" : "45",
+        "vertices" : [ {
+          "x" : 5657,
+          "y" : 607
+        } ]
+      }, {
+        "id" : "69"
+      }, {
+        "id" : "58"
+      }, {
+        "id" : "68"
+      }, {
+        "id" : "48",
         "vertices" : [ {
           "x" : 6357,
           "y" : 607
         } ]
       }, {
-        "id" : "49",
-        "vertices" : [ {
-          "x" : 7057,
-          "y" : 607
-        } ]
+        "id" : "39"
       } ]
     } ],
     "configuration" : {

--- a/docs/workspace.json
+++ b/docs/workspace.json
@@ -3,50 +3,44 @@
   "name" : "Name",
   "description" : "Description",
   "revision" : 0,
-  "lastModifiedDate" : "2021-12-07T17:03:04Z",
+  "lastModifiedDate" : "2021-12-07T17:07:20Z",
   "lastModifiedAgent" : "structurizr-web/2544/diagram",
   "properties" : {
-    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRybk1vZGVsID0gY29tcG9uZW50ICJGaW5kVHJuIE1vZGVsIiAiQnVzaW5lc3MgbG9naWMgYXQgdGhlIGNvcmUgb2YgdGhlIEZpbmRNeVRSTiBzZXJ2aWNlLiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRyblZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgICAgIERRVEFQSUNsaWVudCA9IGNvbXBvbmVudCAiRFFUIEFQSSBDbGllbnQiICJBIGNvbXBvbmVudCB0aGF0IGludGVyYWN0cyB3aXRoIHRoZSBEUVQgQVBJIiAiUnVieSIKICAgICAgICAgICAgWmVuZGVza0NsaWVudCA9IGNvbXBvbmVudCAiWmVuRGVzayBBUEkgQ2xpZW50IiAiQSBjb21wb25lbnQgdGhhdCBpbnRlcmFjdHMgd2l0aCB0aGUgWmVuRGVzayIgIlJ1YnkiCiAgICAgICAgfQogICAgICAgIH0KICAgICAgICBkcXQgPSBzb2Z0d2FyZVN5c3RlbSAiRGF0YWJhc2Ugb2YgUXVhbGlmaWVkIFRlYWNoZXJzIChEUVQpIiAiQSBzeXN0ZW0gdGhhdCBzdG9yZXMgYW5kIG1haW50YWlucyByZWNvcmRzIG9mIHBlb3BsZSBpbiBlZHVjYXRpb24uInsKICAgICAgICAgICAgZHF0QVBJID0gY29udGFpbmVyICJEUVQgQVBJIiAiQVBJIG9mZmVyaW5nIHNvbWUgYmFzaWMgc2VhcmNoIGZ1bmN0aW9uYWxpdHkgb3ZlciB0aGUgRGF0YWJhc2Ugb2YgUXVhbGlmaWVkIFRlYWNoZXJzIChEUVQpIiAiQyBTaGFycCIgIAogICAgICAgICAgICBkcXRDUk0gPSBjb250YWluZXIgIkRRVCBDUk0iICJBIE1pY3Jvc29mdCBDUk0gRHluYW1pY3MgaW1wbGVtZW50YXRpb24gdGhhdCBjb250YWlucyBkYXRhIG9uIHBlb3BsZSB3aXRoIFF1YWxpZmllZCBUZWFjaGVyIFN0YXR1cyAoUVRTKSBhbmQgb3RoZXIgYXR0cmlidXRlcy4iICJNaWNyb3NvZnQgRHluYW1pY3MgQ1JNIgogICAgICAgIH0KCiAgICAgICAgemVuZGVzayA9IHNvZnR3YXJlU3lzdGVtICJaZW5EZXNrIiAiQSBTYWFTIFRpY2tldGluZyBzeXN0ZW0gdGhhdCBpcyB1c2VkIGJ5IHRoZSBUUkEgc3VwcG9ydCB0ZWFtLiIgIlNhYVMgTWFuYWdlZCIKICAgICAgICAKICAgICAgICAjIGRpcmVjdCB1c2VycwogICAgICAgIGludGxxdHNVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgZW5nV2Vsc2hRdHNVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgaXR0Q291cnNlVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIgogICAgICAgIHByb2hpYml0ZWRVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgcGVuc2lvblVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBucHFVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCgogICAgICAgICMgZGVsZWdhdGUgdXNlcnMKICAgICAgICBzY2hvb2xBZG1pblVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCiAgICAgICAgaXR0UHJvdmlkZXJVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIgogICAgICAgIGVtcGxveWVyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIgogICAgICAgIHNlY3RvckRlbGl2ZXJ5T3JncyAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiIKICAgICAgICBzZWN0b3JBc3N1cmFuY2VCb2RpZXMgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCgogICAgICAgICMgcmVsYXRpb25zaGlwcyBiZXR3ZWVuIGNvbnRhaW5lcnMvY29tcG9uZW50cyAgICAgICAgCiAgICAgICAgRFFUQVBJQ2xpZW50IC0+IGRxdEFQSSAiUXVlcmllcyBmb3IgdXNlciBhdHRyaWJ1dGVzIHVzaW5nIgogICAgICAgIFplbmRlc2tDbGllbnQgLT4gemVuZGVzayAiQ3JlYXRlcyB0aWNrZXRzIGluIgogICAgICAgIGRxdEFQSSAtPiBkcXRDUk0gIk1ha2VzIGNhbGxzIHRvIgogICAgICAgIGZpbmRNeVRybkNvbnRyb2xsZXIgLT4gZmluZE15VHJuTW9kZWwgIkV4ZWN1dGVzIGJ1c2luZXNzIGxvZ2ljIGluc2lkZSIKICAgICAgICBmaW5kTXlUcm5Db250cm9sbGVyIC0+IGZpbmRNeVRyblZpZXdzICJJbnRlcmFjdHMgd2l0aCB1c2VycyB1c2luZyIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBlbWFpbENvbXBvbmVudCAiVmVyaWZpZXMgb3duZXJzaGlwIG9mIGVtYWlsIHZpYSIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBEUVRBUElDbGllbnQgIlF1ZXJpZXMgRFFUIHZpYSIKICAgICAgICBmaW5kTXlUcm5Nb2RlbCAtPiBaZW5kZXNrQ2xpZW50ICJDcmVhdGVzIGhlbHBkZXNrIHRpY2tldHMgdmlhIgogICAgfQoKICAgIHZpZXdzIHsgCiAgICAgICAgdGhlbWUgZGVmYXVsdAogICAgfQp9Cg=="
+    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRybk1vZGVsID0gY29tcG9uZW50ICJGaW5kVHJuIE1vZGVsIiAiQnVzaW5lc3MgbG9naWMgYXQgdGhlIGNvcmUgb2YgdGhlIEZpbmRNeVRSTiBzZXJ2aWNlLiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRyblZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgICAgIERRVEFQSUNsaWVudCA9IGNvbXBvbmVudCAiRFFUIEFQSSBDbGllbnQiICJBIGNvbXBvbmVudCB0aGF0IGludGVyYWN0cyB3aXRoIHRoZSBEUVQgQVBJIiAiUnVieSIKICAgICAgICAgICAgWmVuZGVza0NsaWVudCA9IGNvbXBvbmVudCAiWmVuRGVzayBBUEkgQ2xpZW50IiAiQSBjb21wb25lbnQgdGhhdCBpbnRlcmFjdHMgd2l0aCB0aGUgWmVuRGVzayIgIlJ1YnkiCiAgICAgICAgICAgIExvZ2dlciA9IGNvbXBvbmVudCAiTG9nZ2VyIiAiQSBjb21wb25lbnQgdGhhdCBpcyByZXNwb25zaWJsZSBmb3IgbG9nZ2luZyB1c2VyIGFjdGl2aXR5IG9uIHRoZSBzZXJ2aWNlIiAiUnVieSIKICAgICAgICB9CiAgICAgICAgfQogICAgICAgIGRxdCA9IHNvZnR3YXJlU3lzdGVtICJEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJBIHN5c3RlbSB0aGF0IHN0b3JlcyBhbmQgbWFpbnRhaW5zIHJlY29yZHMgb2YgcGVvcGxlIGluIGVkdWNhdGlvbi4iewogICAgICAgICAgICBkcXRBUEkgPSBjb250YWluZXIgIkRRVCBBUEkiICJBUEkgb2ZmZXJpbmcgc29tZSBiYXNpYyBzZWFyY2ggZnVuY3Rpb25hbGl0eSBvdmVyIHRoZSBEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJDIFNoYXJwIiAgCiAgICAgICAgICAgIGRxdENSTSA9IGNvbnRhaW5lciAiRFFUIENSTSIgIkEgTWljcm9zb2Z0IENSTSBEeW5hbWljcyBpbXBsZW1lbnRhdGlvbiB0aGF0IGNvbnRhaW5zIGRhdGEgb24gcGVvcGxlIHdpdGggUXVhbGlmaWVkIFRlYWNoZXIgU3RhdHVzIChRVFMpIGFuZCBvdGhlciBhdHRyaWJ1dGVzLiIgIk1pY3Jvc29mdCBEeW5hbWljcyBDUk0iCiAgICAgICAgfQoKICAgICAgICB6ZW5kZXNrID0gc29mdHdhcmVTeXN0ZW0gIlplbkRlc2siICJBIFNhYVMgVGlja2V0aW5nIHN5c3RlbSB0aGF0IGlzIHVzZWQgYnkgdGhlIFRSQSBzdXBwb3J0IHRlYW0uIiAiU2FhUyBNYW5hZ2VkIgogICAgICAgIAogICAgICAgICMgZGlyZWN0IHVzZXJzCiAgICAgICAgaW50bHF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBlbmdXZWxzaFF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBpdHRDb3Vyc2VVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgcHJvaGliaXRlZFVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBwZW5zaW9uVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIgogICAgICAgIG5wcVVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKCiAgICAgICAgIyBkZWxlZ2F0ZSB1c2VycwogICAgICAgIHNjaG9vbEFkbWluVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiIKICAgICAgICBpdHRQcm92aWRlclVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCiAgICAgICAgZW1wbG95ZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YiCiAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIgogICAgICAgIHNlY3RvckFzc3VyYW5jZUJvZGllcyAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiIKCiAgICAgICAgIyByZWxhdGlvbnNoaXBzIGJldHdlZW4gY29udGFpbmVycy9jb21wb25lbnRzICAgICAgICAKICAgICAgICBEUVRBUElDbGllbnQgLT4gZHF0QVBJICJRdWVyaWVzIGZvciB1c2VyIGF0dHJpYnV0ZXMgdXNpbmciCiAgICAgICAgWmVuZGVza0NsaWVudCAtPiB6ZW5kZXNrICJDcmVhdGVzIHRpY2tldHMgaW4iCiAgICAgICAgZHF0QVBJIC0+IGRxdENSTSAiTWFrZXMgY2FsbHMgdG8iCiAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciAtPiBmaW5kTXlUcm5Nb2RlbCAiRXhlY3V0ZXMgYnVzaW5lc3MgbG9naWMgaW5zaWRlIgogICAgICAgIGZpbmRNeVRybkNvbnRyb2xsZXIgLT4gZmluZE15VHJuVmlld3MgIkludGVyYWN0cyB3aXRoIHVzZXJzIHVzaW5nIgogICAgICAgIGZpbmRNeVRybk1vZGVsIC0+IGVtYWlsQ29tcG9uZW50ICJWZXJpZmllcyBvd25lcnNoaXAgb2YgZW1haWwgdmlhIgogICAgICAgIGZpbmRNeVRybk1vZGVsIC0+IERRVEFQSUNsaWVudCAiUXVlcmllcyBEUVQgdmlhIgogICAgICAgIGZpbmRNeVRybk1vZGVsIC0+IFplbmRlc2tDbGllbnQgIkNyZWF0ZXMgaGVscGRlc2sgdGlja2V0cyB2aWEiCiAgICAgICAgZmluZE15VHJuTW9kZWwgLT4gTG9nZ2VyICJXcml0ZXMgYXVkaXQgbG9ncyB0byIKICAgIH0KCiAgICB2aWV3cyB7IAogICAgICAgIHRoZW1lIGRlZmF1bHQKICAgIH0KfQo="
   },
   "configuration" : { },
   "model" : {
     "people" : [ {
-      "id" : "6",
+      "id" : "8",
       "tags" : "Element,Person",
-      "name" : "Started an NPQ",
+      "name" : "ITT Provider",
       "relationships" : [ {
-        "id" : "39",
+        "id" : "47",
         "tags" : "Relationship",
-        "sourceId" : "6",
-        "destinationId" : "14",
-        "description" : "Uses"
-      }, {
-        "id" : "41",
-        "tags" : "Relationship",
-        "sourceId" : "6",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "40",
-        "tags" : "Relationship",
-        "sourceId" : "6",
+        "sourceId" : "8",
         "destinationId" : "13",
-        "description" : "Uses"
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "48",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "46",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
       } ],
-      "group" : "Non-delegates",
+      "group" : "delegates",
       "location" : "Unspecified"
     }, {
       "id" : "7",
       "tags" : "Element,Person",
       "name" : "School Business Professional",
       "relationships" : [ {
-        "id" : "42",
-        "tags" : "Relationship",
-        "sourceId" : "7",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "44",
+        "id" : "45",
         "tags" : "Relationship",
         "sourceId" : "7",
         "destinationId" : "12",
@@ -55,206 +49,37 @@
         "id" : "43",
         "tags" : "Relationship",
         "sourceId" : "7",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "44",
+        "tags" : "Relationship",
+        "sourceId" : "7",
         "destinationId" : "13",
         "description" : "Uses on behalf of"
       } ],
       "group" : "delegates",
       "location" : "Unspecified"
     }, {
-      "id" : "3",
+      "id" : "6",
       "tags" : "Element,Person",
-      "name" : "Started ITT",
+      "name" : "Started an NPQ",
       "relationships" : [ {
-        "id" : "31",
+        "id" : "42",
         "tags" : "Relationship",
-        "sourceId" : "3",
-        "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "32",
-        "tags" : "Relationship",
-        "sourceId" : "3",
+        "sourceId" : "6",
         "destinationId" : "12",
         "description" : "Uses"
       }, {
-        "id" : "30",
+        "id" : "41",
         "tags" : "Relationship",
-        "sourceId" : "3",
-        "destinationId" : "14",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "9",
-      "tags" : "Element,Person",
-      "name" : "Employers (in education orgs to check status)",
-      "relationships" : [ {
-        "id" : "49",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "48",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "50",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of"
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "4",
-      "tags" : "Element,Person",
-      "name" : "Ex Teacher (Prohibited)",
-      "relationships" : [ {
-        "id" : "34",
-        "tags" : "Relationship",
-        "sourceId" : "4",
+        "sourceId" : "6",
         "destinationId" : "13",
         "description" : "Uses"
       }, {
-        "id" : "33",
+        "id" : "40",
         "tags" : "Relationship",
-        "sourceId" : "4",
-        "destinationId" : "14",
-        "description" : "Uses"
-      }, {
-        "id" : "35",
-        "tags" : "Relationship",
-        "sourceId" : "4",
-        "destinationId" : "12",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "8",
-      "tags" : "Element,Person",
-      "name" : "ITT Provider",
-      "relationships" : [ {
-        "id" : "46",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "47",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "45",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of"
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "11",
-      "tags" : "Element,Person",
-      "name" : "Appropriate bodies- checking data",
-      "relationships" : [ {
-        "id" : "55",
-        "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "56",
-        "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "54",
-        "tags" : "Relationship",
-        "sourceId" : "11",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of"
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "10",
-      "tags" : "Element,Person",
-      "name" : "ITT, NPQ training providers (diff classes of SKITS,HEIs)",
-      "relationships" : [ {
-        "id" : "51",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "14",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "52",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of"
-      }, {
-        "id" : "53",
-        "tags" : "Relationship",
-        "sourceId" : "10",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of"
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "2",
-      "tags" : "Element,Person",
-      "name" : "English/Welsh QTS Holder",
-      "relationships" : [ {
-        "id" : "28",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "29",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "27",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "14",
-        "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "1",
-      "tags" : "Element,Person",
-      "name" : "International recognition QTS",
-      "relationships" : [ {
-        "id" : "26",
-        "tags" : "Relationship",
-        "sourceId" : "1",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "25",
-        "tags" : "Relationship",
-        "sourceId" : "1",
-        "destinationId" : "13",
-        "description" : "Uses"
-      }, {
-        "id" : "24",
-        "tags" : "Relationship",
-        "sourceId" : "1",
+        "sourceId" : "6",
         "destinationId" : "14",
         "description" : "Uses"
       } ],
@@ -268,72 +93,253 @@
         "id" : "38",
         "tags" : "Relationship",
         "sourceId" : "5",
-        "destinationId" : "12",
-        "description" : "Uses"
-      }, {
-        "id" : "36",
-        "tags" : "Relationship",
-        "sourceId" : "5",
-        "destinationId" : "14",
+        "destinationId" : "13",
         "description" : "Uses"
       }, {
         "id" : "37",
         "tags" : "Relationship",
         "sourceId" : "5",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "39",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "12",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "11",
+      "tags" : "Element,Person",
+      "name" : "Appropriate bodies- checking data",
+      "relationships" : [ {
+        "id" : "57",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "55",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "56",
+        "tags" : "Relationship",
+        "sourceId" : "11",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "3",
+      "tags" : "Element,Person",
+      "name" : "Started ITT",
+      "relationships" : [ {
+        "id" : "32",
+        "tags" : "Relationship",
+        "sourceId" : "3",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "33",
+        "tags" : "Relationship",
+        "sourceId" : "3",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "31",
+        "tags" : "Relationship",
+        "sourceId" : "3",
+        "destinationId" : "14",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "2",
+      "tags" : "Element,Person",
+      "name" : "English/Welsh QTS Holder",
+      "relationships" : [ {
+        "id" : "28",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "29",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "30",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "12",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "9",
+      "tags" : "Element,Person",
+      "name" : "Employers (in education orgs to check status)",
+      "relationships" : [ {
+        "id" : "51",
+        "tags" : "Relationship",
+        "sourceId" : "9",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "49",
+        "tags" : "Relationship",
+        "sourceId" : "9",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "50",
+        "tags" : "Relationship",
+        "sourceId" : "9",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "1",
+      "tags" : "Element,Person",
+      "name" : "International recognition QTS",
+      "relationships" : [ {
+        "id" : "27",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "25",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "26",
+        "tags" : "Relationship",
+        "sourceId" : "1",
         "destinationId" : "13",
         "description" : "Uses"
       } ],
       "group" : "Non-delegates",
       "location" : "Unspecified"
+    }, {
+      "id" : "4",
+      "tags" : "Element,Person",
+      "name" : "Ex Teacher (Prohibited)",
+      "relationships" : [ {
+        "id" : "34",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "36",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "35",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "13",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "10",
+      "tags" : "Element,Person",
+      "name" : "ITT, NPQ training providers (diff classes of SKITS,HEIs)",
+      "relationships" : [ {
+        "id" : "54",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "52",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of"
+      }, {
+        "id" : "53",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of"
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
     } ],
     "softwareSystems" : [ {
-      "id" : "20",
+      "id" : "21",
       "tags" : "Element,Software System",
       "name" : "Database of Qualified Teachers (DQT)",
       "description" : "A system that stores and maintains records of people in education.",
       "location" : "Unspecified",
       "containers" : [ {
-        "id" : "21",
+        "id" : "22",
         "tags" : "Element,Container",
         "name" : "DQT API",
         "description" : "API offering some basic search functionality over the Database of Qualified Teachers (DQT)",
         "relationships" : [ {
-          "id" : "66",
+          "id" : "67",
           "tags" : "Relationship",
-          "sourceId" : "21",
-          "destinationId" : "22",
+          "sourceId" : "22",
+          "destinationId" : "23",
           "description" : "Makes calls to"
         } ],
         "technology" : "C Sharp"
       }, {
-        "id" : "22",
+        "id" : "23",
         "tags" : "Element,Container",
         "name" : "DQT CRM",
         "description" : "A Microsoft CRM Dynamics implementation that contains data on people with Qualified Teacher Status (QTS) and other attributes.",
         "technology" : "Microsoft Dynamics CRM"
       } ]
     }, {
+      "id" : "24",
+      "tags" : "Element,Software System,SaaS Managed",
+      "name" : "ZenDesk",
+      "description" : "A SaaS Ticketing system that is used by the TRA support team.",
+      "location" : "Unspecified"
+    }, {
       "id" : "12",
       "tags" : "Element,Software System",
       "name" : "Teacher Identity Service",
       "description" : "A DfE service for users to engage with their DfE Identity",
       "relationships" : [ {
-        "id" : "65",
+        "id" : "63",
         "tags" : "Relationship",
         "sourceId" : "12",
-        "destinationId" : "23",
+        "destinationId" : "21",
+        "description" : "Queries for user attributes using"
+      }, {
+        "id" : "66",
+        "tags" : "Relationship",
+        "sourceId" : "12",
+        "destinationId" : "24",
         "description" : "Creates tickets in"
       }, {
         "id" : "62",
         "tags" : "Relationship",
         "sourceId" : "12",
-        "destinationId" : "20",
-        "description" : "Queries for user attributes using"
-      }, {
-        "id" : "61",
-        "tags" : "Relationship",
-        "sourceId" : "12",
-        "destinationId" : "21",
+        "destinationId" : "22",
         "description" : "Queries for user attributes using"
       } ],
       "location" : "Unspecified",
@@ -343,62 +349,29 @@
         "name" : "Teacher Identity Web Application",
         "description" : "A web application for users to engage with their DfE Identity",
         "relationships" : [ {
-          "id" : "59",
+          "id" : "61",
           "tags" : "Relationship",
           "sourceId" : "13",
           "destinationId" : "21",
           "description" : "Queries for user attributes using"
         }, {
+          "id" : "65",
+          "tags" : "Relationship",
+          "sourceId" : "13",
+          "destinationId" : "24",
+          "description" : "Creates tickets in"
+        }, {
           "id" : "60",
           "tags" : "Relationship",
           "sourceId" : "13",
-          "destinationId" : "20",
+          "destinationId" : "22",
           "description" : "Queries for user attributes using"
-        }, {
-          "id" : "64",
-          "tags" : "Relationship",
-          "sourceId" : "13",
-          "destinationId" : "23",
-          "description" : "Creates tickets in"
         } ],
         "components" : [ {
-          "id" : "14",
+          "id" : "20",
           "tags" : "Element,Component",
-          "name" : "FindTrn Controller",
-          "description" : "A controller written in Ruby that guides a user through finding their TRN",
-          "relationships" : [ {
-            "id" : "68",
-            "tags" : "Relationship",
-            "sourceId" : "14",
-            "destinationId" : "17",
-            "description" : "Interacts with users using"
-          }, {
-            "id" : "67",
-            "tags" : "Relationship",
-            "sourceId" : "14",
-            "destinationId" : "15",
-            "description" : "Executes business logic inside"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "18",
-          "tags" : "Element,Component",
-          "name" : "DQT API Client",
-          "description" : "A component that interacts with the DQT API",
-          "relationships" : [ {
-            "id" : "58",
-            "tags" : "Relationship",
-            "sourceId" : "18",
-            "destinationId" : "20",
-            "description" : "Queries for user attributes using"
-          }, {
-            "id" : "57",
-            "tags" : "Relationship",
-            "sourceId" : "18",
-            "destinationId" : "21",
-            "description" : "Queries for user attributes using"
-          } ],
+          "name" : "Logger",
+          "description" : "A component that is responsible for logging user activity on the service",
           "technology" : "Ruby",
           "size" : 0
         }, {
@@ -409,16 +382,74 @@
           "technology" : "Ruby",
           "size" : 0
         }, {
-          "id" : "19",
+          "id" : "15",
           "tags" : "Element,Component",
-          "name" : "ZenDesk API Client",
-          "description" : "A component that interacts with the ZenDesk",
+          "name" : "FindTrn Model",
+          "description" : "Business logic at the core of the FindMyTRN service.",
           "relationships" : [ {
-            "id" : "63",
+            "id" : "71",
             "tags" : "Relationship",
-            "sourceId" : "19",
-            "destinationId" : "23",
-            "description" : "Creates tickets in"
+            "sourceId" : "15",
+            "destinationId" : "18",
+            "description" : "Queries DQT via"
+          }, {
+            "id" : "72",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "19",
+            "description" : "Creates helpdesk tickets via"
+          }, {
+            "id" : "70",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "16",
+            "description" : "Verifies ownership of email via"
+          }, {
+            "id" : "73",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "20",
+            "description" : "Writes audit logs to"
+          } ],
+          "technology" : "Ruby",
+          "size" : 0
+        }, {
+          "id" : "18",
+          "tags" : "Element,Component",
+          "name" : "DQT API Client",
+          "description" : "A component that interacts with the DQT API",
+          "relationships" : [ {
+            "id" : "59",
+            "tags" : "Relationship",
+            "sourceId" : "18",
+            "destinationId" : "21",
+            "description" : "Queries for user attributes using"
+          }, {
+            "id" : "58",
+            "tags" : "Relationship",
+            "sourceId" : "18",
+            "destinationId" : "22",
+            "description" : "Queries for user attributes using"
+          } ],
+          "technology" : "Ruby",
+          "size" : 0
+        }, {
+          "id" : "14",
+          "tags" : "Element,Component",
+          "name" : "FindTrn Controller",
+          "description" : "A controller written in Ruby that guides a user through finding their TRN",
+          "relationships" : [ {
+            "id" : "69",
+            "tags" : "Relationship",
+            "sourceId" : "14",
+            "destinationId" : "17",
+            "description" : "Interacts with users using"
+          }, {
+            "id" : "68",
+            "tags" : "Relationship",
+            "sourceId" : "14",
+            "destinationId" : "15",
+            "description" : "Executes business logic inside"
           } ],
           "technology" : "Ruby",
           "size" : 0
@@ -430,39 +461,21 @@
           "technology" : "Ruby",
           "size" : 0
         }, {
-          "id" : "15",
+          "id" : "19",
           "tags" : "Element,Component",
-          "name" : "FindTrn Model",
-          "description" : "Business logic at the core of the FindMyTRN service.",
+          "name" : "ZenDesk API Client",
+          "description" : "A component that interacts with the ZenDesk",
           "relationships" : [ {
-            "id" : "70",
+            "id" : "64",
             "tags" : "Relationship",
-            "sourceId" : "15",
-            "destinationId" : "18",
-            "description" : "Queries DQT via"
-          }, {
-            "id" : "71",
-            "tags" : "Relationship",
-            "sourceId" : "15",
-            "destinationId" : "19",
-            "description" : "Creates helpdesk tickets via"
-          }, {
-            "id" : "69",
-            "tags" : "Relationship",
-            "sourceId" : "15",
-            "destinationId" : "16",
-            "description" : "Verifies ownership of email via"
+            "sourceId" : "19",
+            "destinationId" : "24",
+            "description" : "Creates tickets in"
           } ],
           "technology" : "Ruby",
           "size" : 0
         } ]
       } ]
-    }, {
-      "id" : "23",
-      "tags" : "Element,Software System,SaaS Managed",
-      "name" : "ZenDesk",
-      "description" : "A SaaS Ticketing system that is used by the TRA support team.",
-      "location" : "Unspecified"
     } ]
   },
   "documentation" : { },
@@ -492,7 +505,7 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "23",
+        "id" : "24",
         "x" : 3429,
         "y" : 1629
       }, {
@@ -532,7 +545,7 @@
         "x" : 1029,
         "y" : 329
       }, {
-        "id" : "20",
+        "id" : "21",
         "x" : 4179,
         "y" : 1629
       }, {
@@ -541,71 +554,71 @@
         "y" : 329
       } ],
       "relationships" : [ {
-        "id" : "50",
+        "id" : "63"
+      }, {
+        "id" : "51",
         "vertices" : [ {
           "x" : 1579,
           "y" : 833
         } ]
       }, {
-        "id" : "62"
+        "id" : "42"
       }, {
-        "id" : "41"
-      }, {
-        "id" : "65"
-      }, {
-        "id" : "53",
+        "id" : "54",
         "vertices" : [ {
           "x" : 879,
           "y" : 833
         } ]
       }, {
-        "id" : "32",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "29",
+        "id" : "30",
         "vertices" : [ {
           "x" : 6479,
           "y" : 833
         } ]
       }, {
-        "id" : "26",
+        "id" : "27",
         "vertices" : [ {
           "x" : 7179,
           "y" : 833
         } ]
       }, {
-        "id" : "35",
+        "id" : "36",
         "vertices" : [ {
           "x" : 5079,
           "y" : 833
         } ]
       }, {
-        "id" : "44",
+        "id" : "33",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "66"
+      }, {
+        "id" : "45",
         "vertices" : [ {
           "x" : 2979,
           "y" : 833
         } ]
       }, {
-        "id" : "56",
+        "id" : "57",
         "vertices" : [ {
           "x" : 3650,
           "y" : 833
         } ]
       }, {
-        "id" : "47",
+        "id" : "48",
         "vertices" : [ {
           "x" : 2279,
           "y" : 833
         } ]
       }, {
-        "id" : "38"
+        "id" : "39"
       } ]
     } ],
     "systemContextViews" : [ {
-      "softwareSystemId" : "20",
+      "softwareSystemId" : "21",
       "key" : "DatabaseofQualifiedTeachersDQT-SystemContext",
       "paperSize" : "A6_Portrait",
       "dimensions" : {
@@ -626,15 +639,15 @@
         "x" : 208,
         "y" : 208
       }, {
-        "id" : "20",
+        "id" : "21",
         "x" : 208,
         "y" : 808
       } ],
       "relationships" : [ {
-        "id" : "62"
+        "id" : "63"
       } ]
     }, {
-      "softwareSystemId" : "23",
+      "softwareSystemId" : "24",
       "key" : "ZenDesk-SystemContext",
       "paperSize" : "A6_Portrait",
       "dimensions" : {
@@ -651,16 +664,16 @@
       },
       "enterpriseBoundaryVisible" : true,
       "elements" : [ {
-        "id" : "23",
-        "x" : 208,
-        "y" : 808
-      }, {
         "id" : "12",
         "x" : 208,
         "y" : 208
+      }, {
+        "id" : "24",
+        "x" : 208,
+        "y" : 808
       } ],
       "relationships" : [ {
-        "id" : "65"
+        "id" : "66"
       } ]
     }, {
       "softwareSystemId" : "12",
@@ -688,7 +701,7 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "23",
+        "id" : "24",
         "x" : 3429,
         "y" : 1629
       }, {
@@ -728,114 +741,79 @@
         "x" : 1029,
         "y" : 329
       }, {
-        "id" : "20",
-        "x" : 4179,
-        "y" : 1629
-      }, {
         "id" : "10",
         "x" : 329,
         "y" : 329
+      }, {
+        "id" : "21",
+        "x" : 4179,
+        "y" : 1629
       } ],
       "relationships" : [ {
-        "id" : "50",
+        "id" : "51",
         "vertices" : [ {
           "x" : 1579,
           "y" : 833
         } ]
       }, {
-        "id" : "41"
+        "id" : "63"
       }, {
-        "id" : "62"
+        "id" : "42"
       }, {
-        "id" : "53",
+        "id" : "54",
         "vertices" : [ {
           "x" : 879,
           "y" : 833
         } ]
       }, {
-        "id" : "65"
-      }, {
-        "id" : "32",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "29",
+        "id" : "30",
         "vertices" : [ {
           "x" : 6479,
           "y" : 833
         } ]
       }, {
-        "id" : "26",
+        "id" : "27",
         "vertices" : [ {
           "x" : 7179,
           "y" : 833
         } ]
       }, {
-        "id" : "35",
+        "id" : "36",
         "vertices" : [ {
           "x" : 5079,
           "y" : 833
         } ]
       }, {
-        "id" : "44",
+        "id" : "33",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "45",
         "vertices" : [ {
           "x" : 2979,
           "y" : 833
         } ]
       }, {
-        "id" : "56",
+        "id" : "66"
+      }, {
+        "id" : "57",
         "vertices" : [ {
           "x" : 3650,
           "y" : 833
         } ]
       }, {
-        "id" : "47",
+        "id" : "48",
         "vertices" : [ {
           "x" : 2279,
           "y" : 833
         } ]
       }, {
-        "id" : "38"
+        "id" : "39"
       } ]
     } ],
     "containerViews" : [ {
-      "softwareSystemId" : "20",
-      "key" : "DatabaseofQualifiedTeachersDQT-Container",
-      "paperSize" : "A5_Portrait",
-      "dimensions" : {
-        "width" : 1108,
-        "height" : 2020
-      },
-      "automaticLayout" : {
-        "implementation" : "Graphviz",
-        "rankDirection" : "TopBottom",
-        "rankSeparation" : 300,
-        "nodeSeparation" : 300,
-        "edgeSeparation" : 0,
-        "vertices" : false
-      },
-      "externalSoftwareSystemBoundariesVisible" : true,
-      "elements" : [ {
-        "id" : "22",
-        "x" : 329,
-        "y" : 1408
-      }, {
-        "id" : "12",
-        "x" : 329,
-        "y" : 208
-      }, {
-        "id" : "21",
-        "x" : 329,
-        "y" : 808
-      } ],
-      "relationships" : [ {
-        "id" : "61"
-      }, {
-        "id" : "66"
-      } ]
-    }, {
       "softwareSystemId" : "12",
       "key" : "TeacherIdentityService-Container",
       "paperSize" : "A1_Landscape",
@@ -857,13 +835,13 @@
         "x" : 208,
         "y" : 208
       }, {
-        "id" : "23",
-        "x" : 3308,
-        "y" : 1508
-      }, {
         "id" : "13",
         "x" : 3683,
         "y" : 908
+      }, {
+        "id" : "24",
+        "x" : 3308,
+        "y" : 1508
       }, {
         "id" : "1",
         "x" : 908,
@@ -901,72 +879,107 @@
         "x" : 6508,
         "y" : 208
       }, {
-        "id" : "20",
-        "x" : 4058,
-        "y" : 1508
-      }, {
         "id" : "10",
         "x" : 7208,
         "y" : 208
+      }, {
+        "id" : "21",
+        "x" : 4058,
+        "y" : 1508
       } ],
       "relationships" : [ {
-        "id" : "60"
+        "id" : "61"
       }, {
-        "id" : "40"
+        "id" : "50",
+        "vertices" : [ {
+          "x" : 6358,
+          "y" : 608
+        } ]
       }, {
-        "id" : "52",
+        "id" : "41"
+      }, {
+        "id" : "53",
         "vertices" : [ {
           "x" : 7058,
           "y" : 608
         } ]
       }, {
-        "id" : "43",
-        "vertices" : [ {
-          "x" : 4958,
-          "y" : 608
-        } ]
+        "id" : "65"
       }, {
-        "id" : "64"
-      }, {
-        "id" : "31",
+        "id" : "32",
         "vertices" : [ {
           "x" : 2858,
           "y" : 608
         } ]
       }, {
-        "id" : "28",
+        "id" : "29",
         "vertices" : [ {
           "x" : 2158,
           "y" : 608
         } ]
       }, {
-        "id" : "37"
-      }, {
-        "id" : "25",
+        "id" : "26",
         "vertices" : [ {
           "x" : 1458,
           "y" : 608
         } ]
       }, {
-        "id" : "34"
+        "id" : "35"
       }, {
-        "id" : "55",
+        "id" : "44",
+        "vertices" : [ {
+          "x" : 4958,
+          "y" : 608
+        } ]
+      }, {
+        "id" : "56",
         "vertices" : [ {
           "x" : 758,
           "y" : 608
         } ]
       }, {
-        "id" : "46",
+        "id" : "47",
         "vertices" : [ {
           "x" : 5658,
           "y" : 608
         } ]
       }, {
-        "id" : "49",
-        "vertices" : [ {
-          "x" : 6358,
-          "y" : 608
-        } ]
+        "id" : "38"
+      } ]
+    }, {
+      "softwareSystemId" : "21",
+      "key" : "DatabaseofQualifiedTeachersDQT-Container",
+      "paperSize" : "A5_Portrait",
+      "dimensions" : {
+        "width" : 1108,
+        "height" : 2020
+      },
+      "automaticLayout" : {
+        "implementation" : "Graphviz",
+        "rankDirection" : "TopBottom",
+        "rankSeparation" : 300,
+        "nodeSeparation" : 300,
+        "edgeSeparation" : 0,
+        "vertices" : false
+      },
+      "externalSoftwareSystemBoundariesVisible" : true,
+      "elements" : [ {
+        "id" : "22",
+        "x" : 329,
+        "y" : 808
+      }, {
+        "id" : "12",
+        "x" : 329,
+        "y" : 208
+      }, {
+        "id" : "23",
+        "x" : 329,
+        "y" : 1408
+      } ],
+      "relationships" : [ {
+        "id" : "62"
+      }, {
+        "id" : "67"
       } ]
     } ],
     "componentViews" : [ {
@@ -991,8 +1004,8 @@
         "x" : 207,
         "y" : 207
       }, {
-        "id" : "23",
-        "x" : 4057,
+        "id" : "24",
+        "x" : 3682,
         "y" : 2707
       }, {
         "id" : "14",
@@ -1004,7 +1017,7 @@
         "y" : 1507
       }, {
         "id" : "16",
-        "x" : 2557,
+        "x" : 2182,
         "y" : 2107
       }, {
         "id" : "17",
@@ -1012,11 +1025,11 @@
         "y" : 1507
       }, {
         "id" : "18",
-        "x" : 3307,
+        "x" : 2932,
         "y" : 2107
       }, {
         "id" : "19",
-        "x" : 4057,
+        "x" : 3682,
         "y" : 2107
       }, {
         "id" : "1",
@@ -1056,81 +1069,87 @@
         "y" : 207
       }, {
         "id" : "20",
-        "x" : 3307,
-        "y" : 2707
+        "x" : 4432,
+        "y" : 2107
       }, {
         "id" : "10",
         "x" : 7207,
         "y" : 207
+      }, {
+        "id" : "21",
+        "x" : 2932,
+        "y" : 2707
       } ],
       "relationships" : [ {
         "id" : "70"
       }, {
+        "id" : "72"
+      }, {
         "id" : "71"
       }, {
-        "id" : "63"
+        "id" : "40"
       }, {
-        "id" : "51",
+        "id" : "52",
         "vertices" : [ {
           "x" : 7057,
           "y" : 607
         } ]
       }, {
-        "id" : "42",
+        "id" : "73"
+      }, {
+        "id" : "43",
         "vertices" : [ {
           "x" : 4957,
           "y" : 607
         } ]
       }, {
-        "id" : "54",
-        "vertices" : [ {
-          "x" : 757,
-          "y" : 607
-        } ]
+        "id" : "64"
       }, {
-        "id" : "30",
+        "id" : "31",
         "vertices" : [ {
           "x" : 2857,
           "y" : 607
         } ]
       }, {
-        "id" : "27",
+        "id" : "28",
         "vertices" : [ {
           "x" : 2157,
           "y" : 607
         } ]
       }, {
-        "id" : "36"
+        "id" : "37"
       }, {
-        "id" : "24",
+        "id" : "25",
         "vertices" : [ {
           "x" : 1457,
           "y" : 607
         } ]
       }, {
-        "id" : "33"
+        "id" : "34"
       }, {
-        "id" : "67"
-      }, {
-        "id" : "45",
+        "id" : "55",
         "vertices" : [ {
-          "x" : 5657,
+          "x" : 757,
           "y" : 607
         } ]
       }, {
         "id" : "69"
       }, {
-        "id" : "58"
+        "id" : "46",
+        "vertices" : [ {
+          "x" : 5657,
+          "y" : 607
+        } ]
       }, {
         "id" : "68"
       }, {
-        "id" : "48",
+        "id" : "59"
+      }, {
+        "id" : "49",
         "vertices" : [ {
           "x" : 6357,
           "y" : 607
         } ]
-      }, {
-        "id" : "39"
       } ]
     } ],
     "configuration" : {

--- a/docs/workspace.json
+++ b/docs/workspace.json
@@ -3,84 +3,33 @@
   "name" : "Name",
   "description" : "Description",
   "revision" : 0,
-  "lastModifiedDate" : "2021-11-22T15:21:45Z",
+  "lastModifiedDate" : "2021-11-29T15:00:10Z",
   "lastModifiedAgent" : "structurizr-web/2544/diagram",
   "properties" : {
-    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiICAgICAgICAgICAgCiAgICAgICAgICAgIG9tbmlhdXRoSW5XZWJBcHAgPSBjb21wb25lbnQgIk9tbmlBdXRoIiAiQW4gb0F1dGgyL09JREMgY2xpZW50LCB3cml0dGVuIGluIFJ1YnkuIiAiUnVieSBHZW0iCiAgICAgICAgICAgIGFwcFZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgfQogICAgICAgIGlkZW50aXR5QnJva2VyID0gY29udGFpbmVyICJJZGVudGl0eSBEYXRhIEJyb2tlciIgIlRoZSBkYXRhIHN0b3JlIGZvciB0aGUgaWRlbnRpdHkgYnJva2VyLiBDb250YWlucyBhdHRyaWJ1dGVzIGFib3V0IHBlb3BsZSBmb3IgbWF0Y2hpbmcgcHVycG9zZXMiICJQb3N0Z3Jlcy9FbGFzdGljL05lbzRqInsKICAgICAgICAgICAgdGFncyAiRGF0YVN0b3JlIgogICAgICAgIH0KICAgICAgICBpZGVudGl0eUJyb2tlckFQSSA9IGNvbnRhaW5lciAiSWRlbnRpdHkgRGF0YSBCcm9rZXIgQVBJIiAiVGhpcyBBUEkgc2VydmVzIG1hdGNoaW5nIHVzZXIgYXR0cmlidXRlcywgZ2l2ZW4gYSBzZXQgb2Ygb3RoZXIgYXR0cmlidXRlcyBhYm91dCBhIHVzZXIiewogICAgICAgICAgICBhc3NvY2lhdGVDb250cm9sbGVyID0gY29tcG9uZW50ICJBc3NvY2lhdGUgQ29udHJvbGxlciIgIkEgY29udHJvbGxlciB3cml0dGVuIGluIFJ1YnkgdGhhdCBhY2NlcHRzIGFuZCBwcm9jZXNzZXMgaW5jb21pbmcgcmVxdWVzdHMgdG8gYXNzb2NpYXRlIGRhdGEgYXR0cmlidXRlcyB3aXRoIHJlY29yZHMsIG9yIG90aGVyIGF0dHJpYnV0ZXMuIiAiUnVieSIKICAgICAgICAgICAgZmluZENvbnRyb2xsZXIgPSBjb21wb25lbnQgIkZpbmQgQ29udHJvbGxlciIgIkEgY29udHJvbGxlciB3cml0dGVuIGluIFJ1YnkgdGhhdCBhY2NlcHRzIHJlcXVlc3RzIHRvIHNlYXJjaCBmb3IgdXNlciBkYXRhLCBiYXNlZCBvbiBrbm93biB1c2VyIGF0dHJpYnV0ZXMiICJSdWJ5IgogICAgICAgICAgICBkYXRhYmFzZUxheWVyID0gY29tcG9uZW50ICJEYXRhYmFzZSBMYXllciIgIkEgY29tcG9uZW50IGZvciBpbnRlcmFjdGluZyB3aXRoIHRoZSBkYXRhIHN0b3JlIiAiUnVieSIKICAgICAgICAgICAgRFFUQVBJQ2xpZW50ID0gY29tcG9uZW50ICJEUVQgQVBJIENsaWVudCIgIkEgY29tcG9uZW50IHRoYXQgaW50ZXJhY3RzIHdpdGggdGhlIERRVCBBUEkiICJSdWJ5IgogICAgICAgIH0KICAgICAgICAKICAgICAgICBnb3ZVS0ludGVncmF0b3IgPSBjb250YWluZXIgIkdPVi5VSyBJbnRlZ3JhdGlvbiBTZXJ2aWNlIiAiQSBUZWFjaGVyIFNlcnZpY2VzIGxldmVsIGludGVncmF0aW9uIHdpdGggR09WLlVLIEFjY291bnQgYmFzZWQgb24gT0lEQyJ7CiAgICAgICAgICAgIG9wZW5JZENvbm5lY3RTZXJ2ZXIgPSBjb21wb25lbnQgIk9wZW5JRCBDb25uZWN0IFNlcnZlciIgIkFuIGltcGxlbWVudGF0aW9uIG9mIGFuIE9JREMgc2VydmVyIHRoYXQgaXMgY29uZmlndXJlZCB0byBmZWRlcmF0ZSB3aXRoIEdPVi5VSyBBY2NvdW50IiAiUnVieSIKICAgICAgICAgICAgZG9vcmtlZXBlciA9IGNvbXBvbmVudCAiRG9vcmtlZXBlciIgIkFuIG9BdXRoMi9PSURDIHByb3ZpZGVyLCB3cml0dGVuIGluIFJ1YnkuIiAiUnVieSBHZW0iCiAgICAgICAgICAgIG9tbmlhdXRoID0gY29tcG9uZW50ICJPbW5pQXV0aCIgIkFuIG9BdXRoMi9PSURDIGNsaWVudCwgd3JpdHRlbiBpbiBSdWJ5LiIgIlJ1YnkgR2VtIgogICAgICAgIH0KICAgICAgICB9CiAgICAgICAgZHF0ID0gc29mdHdhcmVTeXN0ZW0gIkRhdGFiYXNlIG9mIFF1YWxpZmllZCBUZWFjaGVycyAoRFFUKSIgIkEgc3lzdGVtIHRoYXQgc3RvcmVzIGFuZCBtYWludGFpbnMgcmVjb3JkcyBvZiBwZW9wbGUgaW4gZWR1Y2F0aW9uLiJ7CiAgICAgICAgICAgIGRxdEFQSSA9IGNvbnRhaW5lciAiRFFUIEFQSSIgIkFQSSBvZmZlcmluZyBzb21lIGJhc2ljIHNlYXJjaCBmdW5jdGlvbmFsaXR5IG92ZXIgdGhlIERhdGFiYXNlIG9mIFF1YWxpZmllZCBUZWFjaGVycyAoRFFUKSIgIkMgU2hhcnAiICAKICAgICAgICAgICAgZHF0Q1JNID0gY29udGFpbmVyICJEUVQgQ1JNIiAiQSBNaWNyb3NvZnQgQ1JNIER5bmFtaWNzIGltcGxlbWVudGF0aW9uIHRoYXQgY29udGFpbnMgZGF0YSBvbiBwZW9wbGUgd2l0aCBRdWFsaWZpZWQgVGVhY2hlciBTdGF0dXMgKFFUUykgYW5kIG90aGVyIGF0dHJpYnV0ZXMuIiAiTWljcm9zb2Z0IER5bmFtaWNzIENSTSIKICAgICAgICB9CiAgICAgICAgCiAgICAgICAgIyBkaXJlY3QgdXNlcnMKICAgICAgICBpbnRscXRzVXNlciAtPiB3ZWJhcHAgIlVzZXMiCiAgICAgICAgZW5nV2Vsc2hRdHNVc2VyIC0+IHdlYmFwcCAiVXNlcyIKICAgICAgICBpdHRDb3Vyc2VVc2VyIC0+IHdlYmFwcCAiVXNlcyIKICAgICAgICBwcm9oaWJpdGVkVXNlciAtPiB3ZWJhcHAgIlVzZXMiCiAgICAgICAgcGVuc2lvblVzZXIgLT4gd2ViYXBwICJVc2VzIgogICAgICAgIG5wcVVzZXIgLT4gd2ViYXBwICJVc2VzIgoKICAgICAgICAjIGRlbGVnYXRlIHVzZXJzCiAgICAgICAgc2Nob29sQWRtaW5Vc2VyIC0+IHdlYmFwcCAiVXNlcyBvbiBiZWhhbGYgb2YgLi4uIgogICAgICAgIGl0dFByb3ZpZGVyVXNlciAtPiB3ZWJhcHAgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBlbXBsb3llciAtPiB3ZWJhcHAgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBzZWN0b3JEZWxpdmVyeU9yZ3MgLT4gd2ViYXBwICJVc2VzIG9uIGJlaGFsZiBvZiAuLi4iCiAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzIC0+IHdlYmFwcCAiVXNlcyBvbiBiZWhhbGYgb2YgLi4uIgoKICAgICAgICAjIHJlbGF0aW9uc2hpcHMgYmV0d2VlbiBjb250YWluZXJzL2NvbXBvbmVudHMKICAgICAgICBnb3ZVa0FjY291bnRTU08gPSBzb2Z0d2FyZVN5c3RlbSAiR09WLlVLIEFjY291bnQiICJBIENlbnRyYWwgR292ZXJubWVudCBzeXN0ZW0gcHJvdmlkaW5nIFNTTyBzZXJ2aWNlcyB0byBnb3Zlcm5tZW50IGFnZW5jaWVzIgogICAgICAgIG9tbmlhdXRoSW5XZWJBcHAgLT4gb3BlbklkQ29ubmVjdFNlcnZlciAiQXV0aGVudGljYXRlcyB1c2VycyB1c2luZyIKICAgICAgICBvcGVuSWRDb25uZWN0U2VydmVyIC0+IGdvdlVrQWNjb3VudFNTTyAiRmVkZXJhdGVzIHdpdGgiCiAgICAgICAgb3BlbklkQ29ubmVjdFNlcnZlciAtPiBpZGVudGl0eUJyb2tlckFQSSAiRW5yaWNoZXMgdG9rZW4gd2l0aCB1c2VyIGF0dHJpYnV0ZXMgZnJvbSIKICAgICAgICBvcGVuSWRDb25uZWN0U2VydmVyIC0+IGlkZW50aXR5QnJva2VyQVBJICJVcGRhdGVzIGRhdGEgc3RvcmUgd2l0aCBpbmNvbWluZyBhdHRyaWJ1dGVzIGZyb20gR09WLlVLIEFjY291bnQiCiAgICAgICAgZGF0YWJhc2VMYXllciAtPiBpZGVudGl0eUJyb2tlciAiUGVyc2lzdHMgdXNlciBhdHRyaWJ1dGUgZGF0YSB0byIKICAgICAgICBEUVRBUElDbGllbnQgLT4gZHF0QVBJICJRdWVyaWVzIGZvciB1c2VyIGF0dHJpYnV0ZXMgdXNpbmciCiAgICAgICAgZHF0QVBJIC0+IGRxdENSTSAiTWFrZXMgY2FsbHMgdG8iCiAgICAgICAgb3BlbklkQ29ubmVjdFNlcnZlciAtPiBkb29ya2VlcGVyICJVc2VzIgogICAgICAgIG9wZW5JZENvbm5lY3RTZXJ2ZXIgLT4gb21uaWF1dGggIlVzZXMiCiAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciAtPiBlbWFpbENvbXBvbmVudAogICAgICAgIGZpbmRNeVRybkNvbnRyb2xsZXIgLT4gaWRlbnRpdHlCcm9rZXJBUEkgIlJldHJpZXZlcyB1c2VyIGluZm9ybWF0aW9uIGZyb20iCiAgICAgICAgYXNzb2NpYXRlQ29udHJvbGxlciAtPiBkYXRhYmFzZUxheWVyICJXcml0ZXMgbmV3IGFzc29jaWF0aW9uIGRhdGEgdG8iCiAgICAgICAgZmluZENvbnRyb2xsZXIgLT4gRFFUQVBJQ2xpZW50ICJRdWVyaWVzIERRVCB2aWEiICAgICAgICAKICAgICAgICBmaW5kQ29udHJvbGxlciAtPiBkYXRhYmFzZUxheWVyICJRdWVyaWVzIGFkZGl0aW9uYWwgdXNlciBhdHRyaWJ1dGVzIGluIgogICAgICAgIGZpbmRNeVRybkNvbnRyb2xsZXIgLT4gYXNzb2NpYXRlQ29udHJvbGxlciAiQXNzb2NpYXRlcyBUUk5zIHdpdGggb3RoZXIgY29vcmRpbmF0ZXMiCiAgICB9CgogICAgdmlld3MgeyAKICAgICAgICB0aGVtZSBkZWZhdWx0CiAgICB9Cn0K"
+    "structurizr.dsl" : "d29ya3NwYWNlIHsKCiAgICBtb2RlbCB7ICAgICAgICAKICAgICAgICAgIyBVc2VyIGRlZmluaXRpb25zCiAgICAgICAgIGdyb3VwICJOb24tZGVsZWdhdGVzIiB7CiAgICAgICAgICAgIGludGxxdHNVc2VyID0gcGVyc29uICJJbnRlcm5hdGlvbmFsIHJlY29nbml0aW9uIFFUUyIKICAgICAgICAgICAgZW5nV2Vsc2hRdHNVc2VyID0gcGVyc29uICJFbmdsaXNoL1dlbHNoIFFUUyBIb2xkZXIiCiAgICAgICAgICAgIGl0dENvdXJzZVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgSVRUIgogICAgICAgICAgICBwcm9oaWJpdGVkVXNlciA9IHBlcnNvbiAiRXggVGVhY2hlciAoUHJvaGliaXRlZCkiCiAgICAgICAgICAgIHBlbnNpb25Vc2VyID0gcGVyc29uICJQZW5zaW9uZXIgKFRQUykiCiAgICAgICAgICAgIG5wcVVzZXIgPSBwZXJzb24gIlN0YXJ0ZWQgYW4gTlBRIgogICAgICAgIH0KCiAgICAgICAgZ3JvdXAgZGVsZWdhdGVzIHsKICAgICAgICAgICAgc2Nob29sQWRtaW5Vc2VyID0gcGVyc29uICJTY2hvb2wgQnVzaW5lc3MgUHJvZmVzc2lvbmFsIgogICAgICAgICAgICBpdHRQcm92aWRlclVzZXIgPSBwZXJzb24gIklUVCBQcm92aWRlciIKICAgICAgICAgICAgZW1wbG95ZXIgPSBwZXJzb24gIkVtcGxveWVycyAoaW4gZWR1Y2F0aW9uIG9yZ3MgdG8gY2hlY2sgc3RhdHVzKSIKICAgICAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzID0gcGVyc29uICJJVFQsIE5QUSB0cmFpbmluZyBwcm92aWRlcnMgKGRpZmYgY2xhc3NlcyBvZiBTS0lUUyxIRUlzKSIKICAgICAgICAgICAgc2VjdG9yQXNzdXJhbmNlQm9kaWVzID0gcGVyc29uICJBcHByb3ByaWF0ZSBib2RpZXMtIGNoZWNraW5nIGRhdGEiCiAgICAgICAgfQoKICAgICAgICBzb2Z0d2FyZVN5c3RlbSA9IHNvZnR3YXJlU3lzdGVtICJUZWFjaGVyIElkZW50aXR5IFNlcnZpY2UiICJBIERmRSBzZXJ2aWNlIGZvciB1c2VycyB0byBlbmdhZ2Ugd2l0aCB0aGVpciBEZkUgSWRlbnRpdHkiewogICAgICAgIHdlYmFwcCA9IGNvbnRhaW5lciAiVGVhY2hlciBJZGVudGl0eSBXZWIgQXBwbGljYXRpb24iICJBIHdlYiBhcHBsaWNhdGlvbiBmb3IgdXNlcnMgdG8gZW5nYWdlIHdpdGggdGhlaXIgRGZFIElkZW50aXR5InsKICAgICAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciA9IGNvbXBvbmVudCAiRmluZFRybiBDb250cm9sbGVyIiAiQSBjb250cm9sbGVyIHdyaXR0ZW4gaW4gUnVieSB0aGF0IGd1aWRlcyBhIHVzZXIgdGhyb3VnaCBmaW5kaW5nIHRoZWlyIFRSTiIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRybk1vZGVsID0gY29tcG9uZW50ICJGaW5kVHJuIE1vZGVsIiAiQnVzaW5lc3MgbG9naWMgYXQgdGhlIGNvcmUgb2YgdGhlIEZpbmRNeVRSTiBzZXJ2aWNlLiIgIlJ1YnkiCiAgICAgICAgICAgIGVtYWlsQ29tcG9uZW50ID0gY29tcG9uZW50ICJFbWFpbCB2ZXJpZmljYXRpb24gY29tcG9uZW50IiAiQSBjb21wb25lbnQgdGhhdCBwcm92ZXMgYSB1c2VyIGhhcyBhY2Nlc3MgdG8gYW4gZW1haWwgYWRkcmVzcyIgIlJ1YnkiCiAgICAgICAgICAgIGZpbmRNeVRyblZpZXdzID0gY29tcG9uZW50ICJXZWIgVUkgVmlld3MiICJWaWV3cyB3cml0dGVuIGluIFJ1YnkgdGhhdCBkZWxpdmVyIHRoZSBVSSIgIlJ1YnkiCiAgICAgICAgICAgIERRVEFQSUNsaWVudCA9IGNvbXBvbmVudCAiRFFUIEFQSSBDbGllbnQiICJBIGNvbXBvbmVudCB0aGF0IGludGVyYWN0cyB3aXRoIHRoZSBEUVQgQVBJIiAiUnVieSIKICAgICAgICB9CiAgICAgICAgfQogICAgICAgIGRxdCA9IHNvZnR3YXJlU3lzdGVtICJEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJBIHN5c3RlbSB0aGF0IHN0b3JlcyBhbmQgbWFpbnRhaW5zIHJlY29yZHMgb2YgcGVvcGxlIGluIGVkdWNhdGlvbi4iewogICAgICAgICAgICBkcXRBUEkgPSBjb250YWluZXIgIkRRVCBBUEkiICJBUEkgb2ZmZXJpbmcgc29tZSBiYXNpYyBzZWFyY2ggZnVuY3Rpb25hbGl0eSBvdmVyIHRoZSBEYXRhYmFzZSBvZiBRdWFsaWZpZWQgVGVhY2hlcnMgKERRVCkiICJDIFNoYXJwIiAgCiAgICAgICAgICAgIGRxdENSTSA9IGNvbnRhaW5lciAiRFFUIENSTSIgIkEgTWljcm9zb2Z0IENSTSBEeW5hbWljcyBpbXBsZW1lbnRhdGlvbiB0aGF0IGNvbnRhaW5zIGRhdGEgb24gcGVvcGxlIHdpdGggUXVhbGlmaWVkIFRlYWNoZXIgU3RhdHVzIChRVFMpIGFuZCBvdGhlciBhdHRyaWJ1dGVzLiIgIk1pY3Jvc29mdCBEeW5hbWljcyBDUk0iCiAgICAgICAgfQogICAgICAgIAogICAgICAgICMgZGlyZWN0IHVzZXJzCiAgICAgICAgaW50bHF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBlbmdXZWxzaFF0c1VzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBpdHRDb3Vyc2VVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMiCiAgICAgICAgcHJvaGliaXRlZFVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKICAgICAgICBwZW5zaW9uVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIgogICAgICAgIG5wcVVzZXIgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyIKCiAgICAgICAgIyBkZWxlZ2F0ZSB1c2VycwogICAgICAgIHNjaG9vbEFkbWluVXNlciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiAuLi4iCiAgICAgICAgaXR0UHJvdmlkZXJVc2VyIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBlbXBsb3llciAtPiBmaW5kTXlUcm5Db250cm9sbGVyICJVc2VzIG9uIGJlaGFsZiBvZiAuLi4iCiAgICAgICAgc2VjdG9yRGVsaXZlcnlPcmdzIC0+IGZpbmRNeVRybkNvbnRyb2xsZXIgIlVzZXMgb24gYmVoYWxmIG9mIC4uLiIKICAgICAgICBzZWN0b3JBc3N1cmFuY2VCb2RpZXMgLT4gZmluZE15VHJuQ29udHJvbGxlciAiVXNlcyBvbiBiZWhhbGYgb2YgLi4uIgoKICAgICAgICAjIHJlbGF0aW9uc2hpcHMgYmV0d2VlbiBjb250YWluZXJzL2NvbXBvbmVudHMgICAgICAgIAogICAgICAgIERRVEFQSUNsaWVudCAtPiBkcXRBUEkgIlF1ZXJpZXMgZm9yIHVzZXIgYXR0cmlidXRlcyB1c2luZyIKICAgICAgICBkcXRBUEkgLT4gZHF0Q1JNICJNYWtlcyBjYWxscyB0byIKICAgICAgICBmaW5kTXlUcm5Db250cm9sbGVyIC0+IGZpbmRNeVRybk1vZGVsICJFeGVjdXRlcyBidXNpbmVzcyBsb2dpYyBpbnNpZGUiCiAgICAgICAgZmluZE15VHJuQ29udHJvbGxlciAtPiBmaW5kTXlUcm5WaWV3cyAiSW50ZXJhY3RzIHdpdGggdXNlcnMgdXNpbmciCiAgICAgICAgZmluZE15VHJuTW9kZWwgLT4gZW1haWxDb21wb25lbnQgIlZlcmlmaWVzIG93bmVyc2hpcCBvZiBlbWFpbCB2aWEiCiAgICAgICAgZmluZE15VHJuTW9kZWwgLT4gRFFUQVBJQ2xpZW50ICJRdWVyaWVzIERRVCB2aWEiCiAgICB9CgogICAgdmlld3MgeyAKICAgICAgICB0aGVtZSBkZWZhdWx0CiAgICB9Cn0K"
   },
   "configuration" : { },
   "model" : {
     "people" : [ {
-      "id" : "9",
-      "tags" : "Element,Person",
-      "name" : "Employers (in education orgs to check status)",
-      "relationships" : [ {
-        "id" : "47",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "48",
-        "tags" : "Relationship",
-        "sourceId" : "9",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "7",
-      "tags" : "Element,Person",
-      "name" : "School Business Professional",
-      "relationships" : [ {
-        "id" : "43",
-        "tags" : "Relationship",
-        "sourceId" : "7",
-        "destinationId" : "13",
-        "description" : "Uses on behalf of ..."
-      }, {
-        "id" : "44",
-        "tags" : "Relationship",
-        "sourceId" : "7",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
       "id" : "11",
       "tags" : "Element,Person",
       "name" : "Appropriate bodies- checking data",
       "relationships" : [ {
-        "id" : "51",
+        "id" : "54",
         "tags" : "Relationship",
         "sourceId" : "11",
-        "destinationId" : "13",
+        "destinationId" : "12",
         "description" : "Uses on behalf of ..."
       }, {
         "id" : "52",
         "tags" : "Relationship",
         "sourceId" : "11",
-        "destinationId" : "12",
-        "description" : "Uses on behalf of ..."
-      } ],
-      "group" : "delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "8",
-      "tags" : "Element,Person",
-      "name" : "ITT Provider",
-      "relationships" : [ {
-        "id" : "46",
-        "tags" : "Relationship",
-        "sourceId" : "8",
-        "destinationId" : "12",
+        "destinationId" : "14",
         "description" : "Uses on behalf of ..."
       }, {
-        "id" : "45",
+        "id" : "53",
         "tags" : "Relationship",
-        "sourceId" : "8",
+        "sourceId" : "11",
         "destinationId" : "13",
         "description" : "Uses on behalf of ..."
       } ],
@@ -91,13 +40,19 @@
       "tags" : "Element,Person",
       "name" : "Ex Teacher (Prohibited)",
       "relationships" : [ {
-        "id" : "37",
+        "id" : "31",
+        "tags" : "Relationship",
+        "sourceId" : "4",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "32",
         "tags" : "Relationship",
         "sourceId" : "4",
         "destinationId" : "13",
         "description" : "Uses"
       }, {
-        "id" : "38",
+        "id" : "33",
         "tags" : "Relationship",
         "sourceId" : "4",
         "destinationId" : "12",
@@ -106,36 +61,148 @@
       "group" : "Non-delegates",
       "location" : "Unspecified"
     }, {
-      "id" : "6",
+      "id" : "5",
       "tags" : "Element,Person",
-      "name" : "Started an NPQ",
+      "name" : "Pensioner (TPS)",
       "relationships" : [ {
-        "id" : "42",
+        "id" : "36",
         "tags" : "Relationship",
-        "sourceId" : "6",
+        "sourceId" : "5",
         "destinationId" : "12",
         "description" : "Uses"
       }, {
+        "id" : "35",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "34",
+        "tags" : "Relationship",
+        "sourceId" : "5",
+        "destinationId" : "14",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "2",
+      "tags" : "Element,Person",
+      "name" : "English/Welsh QTS Holder",
+      "relationships" : [ {
+        "id" : "26",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "13",
+        "description" : "Uses"
+      }, {
+        "id" : "25",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "27",
+        "tags" : "Relationship",
+        "sourceId" : "2",
+        "destinationId" : "12",
+        "description" : "Uses"
+      } ],
+      "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "7",
+      "tags" : "Element,Person",
+      "name" : "School Business Professional",
+      "relationships" : [ {
+        "id" : "42",
+        "tags" : "Relationship",
+        "sourceId" : "7",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of ..."
+      }, {
+        "id" : "40",
+        "tags" : "Relationship",
+        "sourceId" : "7",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of ..."
+      }, {
         "id" : "41",
         "tags" : "Relationship",
-        "sourceId" : "6",
+        "sourceId" : "7",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of ..."
+      } ],
+      "group" : "delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "1",
+      "tags" : "Element,Person",
+      "name" : "International recognition QTS",
+      "relationships" : [ {
+        "id" : "22",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "24",
+        "tags" : "Relationship",
+        "sourceId" : "1",
+        "destinationId" : "12",
+        "description" : "Uses"
+      }, {
+        "id" : "23",
+        "tags" : "Relationship",
+        "sourceId" : "1",
         "destinationId" : "13",
         "description" : "Uses"
       } ],
       "group" : "Non-delegates",
+      "location" : "Unspecified"
+    }, {
+      "id" : "8",
+      "tags" : "Element,Person",
+      "name" : "ITT Provider",
+      "relationships" : [ {
+        "id" : "45",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "12",
+        "description" : "Uses on behalf of ..."
+      }, {
+        "id" : "43",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of ..."
+      }, {
+        "id" : "44",
+        "tags" : "Relationship",
+        "sourceId" : "8",
+        "destinationId" : "13",
+        "description" : "Uses on behalf of ..."
+      } ],
+      "group" : "delegates",
       "location" : "Unspecified"
     }, {
       "id" : "10",
       "tags" : "Element,Person",
       "name" : "ITT, NPQ training providers (diff classes of SKITS,HEIs)",
       "relationships" : [ {
-        "id" : "50",
+        "id" : "49",
+        "tags" : "Relationship",
+        "sourceId" : "10",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of ..."
+      }, {
+        "id" : "51",
         "tags" : "Relationship",
         "sourceId" : "10",
         "destinationId" : "12",
         "description" : "Uses on behalf of ..."
       }, {
-        "id" : "49",
+        "id" : "50",
         "tags" : "Relationship",
         "sourceId" : "10",
         "destinationId" : "13",
@@ -144,19 +211,25 @@
       "group" : "delegates",
       "location" : "Unspecified"
     }, {
-      "id" : "5",
+      "id" : "6",
       "tags" : "Element,Person",
-      "name" : "Pensioner (TPS)",
+      "name" : "Started an NPQ",
       "relationships" : [ {
-        "id" : "40",
+        "id" : "39",
         "tags" : "Relationship",
-        "sourceId" : "5",
+        "sourceId" : "6",
         "destinationId" : "12",
         "description" : "Uses"
       }, {
-        "id" : "39",
+        "id" : "37",
         "tags" : "Relationship",
-        "sourceId" : "5",
+        "sourceId" : "6",
+        "destinationId" : "14",
+        "description" : "Uses"
+      }, {
+        "id" : "38",
+        "tags" : "Relationship",
+        "sourceId" : "6",
         "destinationId" : "13",
         "description" : "Uses"
       } ],
@@ -167,57 +240,50 @@
       "tags" : "Element,Person",
       "name" : "Started ITT",
       "relationships" : [ {
-        "id" : "35",
+        "id" : "29",
         "tags" : "Relationship",
         "sourceId" : "3",
         "destinationId" : "13",
         "description" : "Uses"
       }, {
-        "id" : "36",
+        "id" : "30",
         "tags" : "Relationship",
         "sourceId" : "3",
         "destinationId" : "12",
         "description" : "Uses"
-      } ],
-      "group" : "Non-delegates",
-      "location" : "Unspecified"
-    }, {
-      "id" : "2",
-      "tags" : "Element,Person",
-      "name" : "English/Welsh QTS Holder",
-      "relationships" : [ {
-        "id" : "34",
-        "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "12",
-        "description" : "Uses"
       }, {
-        "id" : "33",
+        "id" : "28",
         "tags" : "Relationship",
-        "sourceId" : "2",
-        "destinationId" : "13",
+        "sourceId" : "3",
+        "destinationId" : "14",
         "description" : "Uses"
       } ],
       "group" : "Non-delegates",
       "location" : "Unspecified"
     }, {
-      "id" : "1",
+      "id" : "9",
       "tags" : "Element,Person",
-      "name" : "International recognition QTS",
+      "name" : "Employers (in education orgs to check status)",
       "relationships" : [ {
-        "id" : "31",
+        "id" : "47",
         "tags" : "Relationship",
-        "sourceId" : "1",
+        "sourceId" : "9",
         "destinationId" : "13",
-        "description" : "Uses"
+        "description" : "Uses on behalf of ..."
       }, {
-        "id" : "32",
+        "id" : "46",
         "tags" : "Relationship",
-        "sourceId" : "1",
+        "sourceId" : "9",
+        "destinationId" : "14",
+        "description" : "Uses on behalf of ..."
+      }, {
+        "id" : "48",
+        "tags" : "Relationship",
+        "sourceId" : "9",
         "destinationId" : "12",
-        "description" : "Uses"
+        "description" : "Uses on behalf of ..."
       } ],
-      "group" : "Non-delegates",
+      "group" : "delegates",
       "location" : "Unspecified"
     } ],
     "softwareSystems" : [ {
@@ -226,250 +292,82 @@
       "name" : "Teacher Identity Service",
       "description" : "A DfE service for users to engage with their DfE Identity",
       "relationships" : [ {
-        "id" : "70",
+        "id" : "59",
         "tags" : "Relationship",
         "sourceId" : "12",
-        "destinationId" : "29",
+        "destinationId" : "20",
         "description" : "Queries for user attributes using"
       }, {
         "id" : "60",
         "tags" : "Relationship",
         "sourceId" : "12",
-        "destinationId" : "53",
-        "description" : "Federates with"
-      }, {
-        "id" : "71",
-        "tags" : "Relationship",
-        "sourceId" : "12",
-        "destinationId" : "28",
+        "destinationId" : "19",
         "description" : "Queries for user attributes using"
       } ],
       "location" : "Unspecified",
       "containers" : [ {
-        "id" : "18",
-        "tags" : "Element,Container,DataStore",
-        "name" : "Identity Data Broker",
-        "description" : "The data store for the identity broker. Contains attributes about people for matching purposes",
-        "technology" : "Postgres/Elastic/Neo4j"
-      }, {
-        "id" : "19",
-        "tags" : "Element,Container",
-        "name" : "Identity Data Broker API",
-        "description" : "This API serves matching user attributes, given a set of other attributes about a user",
-        "relationships" : [ {
-          "id" : "69",
-          "tags" : "Relationship",
-          "sourceId" : "19",
-          "destinationId" : "28",
-          "description" : "Queries for user attributes using"
-        }, {
-          "id" : "65",
-          "tags" : "Relationship",
-          "sourceId" : "19",
-          "destinationId" : "18",
-          "description" : "Persists user attribute data to"
-        }, {
-          "id" : "68",
-          "tags" : "Relationship",
-          "sourceId" : "19",
-          "destinationId" : "29",
-          "description" : "Queries for user attributes using"
-        } ],
-        "components" : [ {
-          "id" : "20",
-          "tags" : "Element,Component",
-          "name" : "Associate Controller",
-          "description" : "A controller written in Ruby that accepts and processes incoming requests to associate data attributes with records, or other attributes.",
-          "relationships" : [ {
-            "id" : "78",
-            "tags" : "Relationship",
-            "sourceId" : "20",
-            "destinationId" : "22",
-            "description" : "Writes new association data to"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "23",
-          "tags" : "Element,Component",
-          "name" : "DQT API Client",
-          "description" : "A component that interacts with the DQT API",
-          "relationships" : [ {
-            "id" : "67",
-            "tags" : "Relationship",
-            "sourceId" : "23",
-            "destinationId" : "28",
-            "description" : "Queries for user attributes using"
-          }, {
-            "id" : "66",
-            "tags" : "Relationship",
-            "sourceId" : "23",
-            "destinationId" : "29",
-            "description" : "Queries for user attributes using"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "21",
-          "tags" : "Element,Component",
-          "name" : "Find Controller",
-          "description" : "A controller written in Ruby that accepts requests to search for user data, based on known user attributes",
-          "relationships" : [ {
-            "id" : "80",
-            "tags" : "Relationship",
-            "sourceId" : "21",
-            "destinationId" : "22",
-            "description" : "Queries additional user attributes in"
-          }, {
-            "id" : "79",
-            "tags" : "Relationship",
-            "sourceId" : "21",
-            "destinationId" : "23",
-            "description" : "Queries DQT via"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "22",
-          "tags" : "Element,Component",
-          "name" : "Database Layer",
-          "description" : "A component for interacting with the data store",
-          "relationships" : [ {
-            "id" : "64",
-            "tags" : "Relationship",
-            "sourceId" : "22",
-            "destinationId" : "18",
-            "description" : "Persists user attribute data to"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        } ]
-      }, {
-        "id" : "24",
-        "tags" : "Element,Container",
-        "name" : "GOV.UK Integration Service",
-        "description" : "A Teacher Services level integration with GOV.UK Account based on OIDC",
-        "relationships" : [ {
-          "id" : "62",
-          "tags" : "Relationship",
-          "sourceId" : "24",
-          "destinationId" : "19",
-          "description" : "Enriches token with user attributes from"
-        }, {
-          "id" : "59",
-          "tags" : "Relationship",
-          "sourceId" : "24",
-          "destinationId" : "53",
-          "description" : "Federates with"
-        } ],
-        "components" : [ {
-          "id" : "25",
-          "tags" : "Element,Component",
-          "name" : "OpenID Connect Server",
-          "description" : "An implementation of an OIDC server that is configured to federate with GOV.UK Account",
-          "relationships" : [ {
-            "id" : "58",
-            "tags" : "Relationship",
-            "sourceId" : "25",
-            "destinationId" : "53",
-            "description" : "Federates with"
-          }, {
-            "id" : "61",
-            "tags" : "Relationship",
-            "sourceId" : "25",
-            "destinationId" : "19",
-            "description" : "Enriches token with user attributes from"
-          }, {
-            "id" : "63",
-            "tags" : "Relationship",
-            "sourceId" : "25",
-            "destinationId" : "19",
-            "description" : "Updates data store with incoming attributes from GOV.UK Account"
-          }, {
-            "id" : "73",
-            "tags" : "Relationship",
-            "sourceId" : "25",
-            "destinationId" : "26",
-            "description" : "Uses"
-          }, {
-            "id" : "74",
-            "tags" : "Relationship",
-            "sourceId" : "25",
-            "destinationId" : "27",
-            "description" : "Uses"
-          } ],
-          "technology" : "Ruby",
-          "size" : 0
-        }, {
-          "id" : "27",
-          "tags" : "Element,Component",
-          "name" : "OmniAuth",
-          "description" : "An oAuth2/OIDC client, written in Ruby.",
-          "technology" : "Ruby Gem",
-          "size" : 0
-        }, {
-          "id" : "26",
-          "tags" : "Element,Component",
-          "name" : "Doorkeeper",
-          "description" : "An oAuth2/OIDC provider, written in Ruby.",
-          "technology" : "Ruby Gem",
-          "size" : 0
-        } ]
-      }, {
         "id" : "13",
         "tags" : "Element,Container",
         "name" : "Teacher Identity Web Application",
         "description" : "A web application for users to engage with their DfE Identity",
         "relationships" : [ {
-          "id" : "56",
-          "tags" : "Relationship",
-          "sourceId" : "13",
-          "destinationId" : "25",
-          "description" : "Authenticates users using"
-        }, {
-          "id" : "77",
+          "id" : "58",
           "tags" : "Relationship",
           "sourceId" : "13",
           "destinationId" : "19",
-          "description" : "Retrieves user information from"
+          "description" : "Queries for user attributes using"
         }, {
           "id" : "57",
           "tags" : "Relationship",
           "sourceId" : "13",
-          "destinationId" : "24",
-          "description" : "Authenticates users using"
-        }, {
-          "id" : "82",
-          "tags" : "Relationship",
-          "sourceId" : "13",
           "destinationId" : "20",
-          "description" : "Associates TRNs with other coordinates"
+          "description" : "Queries for user attributes using"
         } ],
         "components" : [ {
           "id" : "16",
           "tags" : "Element,Component",
-          "name" : "OmniAuth",
-          "description" : "An oAuth2/OIDC client, written in Ruby.",
-          "relationships" : [ {
-            "id" : "55",
-            "tags" : "Relationship",
-            "sourceId" : "16",
-            "destinationId" : "24",
-            "description" : "Authenticates users using"
-          }, {
-            "id" : "54",
-            "tags" : "Relationship",
-            "sourceId" : "16",
-            "destinationId" : "25",
-            "description" : "Authenticates users using"
-          } ],
-          "technology" : "Ruby Gem",
+          "name" : "Email verification component",
+          "description" : "A component that proves a user has access to an email address",
+          "technology" : "Ruby",
           "size" : 0
         }, {
           "id" : "15",
           "tags" : "Element,Component",
-          "name" : "Email verification component",
-          "description" : "A component that proves a user has access to an email address",
+          "name" : "FindTrn Model",
+          "description" : "Business logic at the core of the FindMyTRN service.",
+          "relationships" : [ {
+            "id" : "65",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "18",
+            "description" : "Queries DQT via"
+          }, {
+            "id" : "64",
+            "tags" : "Relationship",
+            "sourceId" : "15",
+            "destinationId" : "16",
+            "description" : "Verifies ownership of email via"
+          } ],
+          "technology" : "Ruby",
+          "size" : 0
+        }, {
+          "id" : "18",
+          "tags" : "Element,Component",
+          "name" : "DQT API Client",
+          "description" : "A component that interacts with the DQT API",
+          "relationships" : [ {
+            "id" : "55",
+            "tags" : "Relationship",
+            "sourceId" : "18",
+            "destinationId" : "20",
+            "description" : "Queries for user attributes using"
+          }, {
+            "id" : "56",
+            "tags" : "Relationship",
+            "sourceId" : "18",
+            "destinationId" : "19",
+            "description" : "Queries for user attributes using"
+          } ],
           "technology" : "Ruby",
           "size" : 0
         }, {
@@ -485,54 +383,43 @@
           "name" : "FindTrn Controller",
           "description" : "A controller written in Ruby that guides a user through finding their TRN",
           "relationships" : [ {
-            "id" : "81",
+            "id" : "63",
             "tags" : "Relationship",
             "sourceId" : "14",
-            "destinationId" : "20",
-            "description" : "Associates TRNs with other coordinates"
+            "destinationId" : "17",
+            "description" : "Interacts with users using"
           }, {
-            "id" : "76",
+            "id" : "62",
             "tags" : "Relationship",
             "sourceId" : "14",
-            "destinationId" : "19",
-            "description" : "Retrieves user information from"
-          }, {
-            "id" : "75",
-            "tags" : "Relationship",
-            "sourceId" : "14",
-            "destinationId" : "15"
+            "destinationId" : "15",
+            "description" : "Executes business logic inside"
           } ],
           "technology" : "Ruby",
           "size" : 0
         } ]
       } ]
     }, {
-      "id" : "53",
-      "tags" : "Element,Software System",
-      "name" : "GOV.UK Account",
-      "description" : "A Central Government system providing SSO services to government agencies",
-      "location" : "Unspecified"
-    }, {
-      "id" : "28",
+      "id" : "19",
       "tags" : "Element,Software System",
       "name" : "Database of Qualified Teachers (DQT)",
       "description" : "A system that stores and maintains records of people in education.",
       "location" : "Unspecified",
       "containers" : [ {
-        "id" : "29",
+        "id" : "20",
         "tags" : "Element,Container",
         "name" : "DQT API",
         "description" : "API offering some basic search functionality over the Database of Qualified Teachers (DQT)",
         "relationships" : [ {
-          "id" : "72",
+          "id" : "61",
           "tags" : "Relationship",
-          "sourceId" : "29",
-          "destinationId" : "30",
+          "sourceId" : "20",
+          "destinationId" : "21",
           "description" : "Makes calls to"
         } ],
         "technology" : "C Sharp"
       }, {
-        "id" : "30",
+        "id" : "21",
         "tags" : "Element,Container",
         "name" : "DQT CRM",
         "description" : "A Microsoft CRM Dynamics implementation that contains data on people with Qualified Teacher Status (QTS) and other attributes.",
@@ -567,8 +454,8 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "28",
-        "x" : 3429,
+        "id" : "19",
+        "x" : 3804,
         "y" : 1629
       }, {
         "id" : "1",
@@ -607,60 +494,58 @@
         "x" : 1029,
         "y" : 329
       }, {
-        "id" : "53",
-        "x" : 4179,
-        "y" : 1629
-      }, {
         "id" : "10",
         "x" : 329,
         "y" : 329
       } ],
       "relationships" : [ {
-        "id" : "71"
-      }, {
         "id" : "60"
       }, {
-        "id" : "50",
+        "id" : "51",
         "vertices" : [ {
           "x" : 879,
           "y" : 833
         } ]
       }, {
-        "id" : "40"
-      }, {
-        "id" : "52",
-        "vertices" : [ {
-          "x" : 3650,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "42"
-      }, {
-        "id" : "32",
-        "vertices" : [ {
-          "x" : 7179,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "36",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "34",
-        "vertices" : [ {
-          "x" : 6479,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "44",
+        "id" : "42",
         "vertices" : [ {
           "x" : 2979,
           "y" : 833
         } ]
       }, {
-        "id" : "46",
+        "id" : "54",
+        "vertices" : [ {
+          "x" : 3650,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "30",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "27",
+        "vertices" : [ {
+          "x" : 6479,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "36"
+      }, {
+        "id" : "24",
+        "vertices" : [ {
+          "x" : 7179,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "33",
+        "vertices" : [ {
+          "x" : 5079,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "45",
         "vertices" : [ {
           "x" : 2279,
           "y" : 833
@@ -672,16 +557,12 @@
           "y" : 833
         } ]
       }, {
-        "id" : "38",
-        "vertices" : [ {
-          "x" : 5079,
-          "y" : 833
-        } ]
+        "id" : "39"
       } ]
     } ],
     "systemContextViews" : [ {
-      "softwareSystemId" : "53",
-      "key" : "GOVUKAccount-SystemContext",
+      "softwareSystemId" : "19",
+      "key" : "DatabaseofQualifiedTeachersDQT-SystemContext",
       "paperSize" : "A6_Portrait",
       "dimensions" : {
         "width" : 866,
@@ -701,7 +582,7 @@
         "x" : 208,
         "y" : 208
       }, {
-        "id" : "53",
+        "id" : "19",
         "x" : 208,
         "y" : 808
       } ],
@@ -734,8 +615,8 @@
         "x" : 3804,
         "y" : 1029
       }, {
-        "id" : "28",
-        "x" : 3429,
+        "id" : "19",
+        "x" : 3804,
         "y" : 1629
       }, {
         "id" : "1",
@@ -774,60 +655,58 @@
         "x" : 1029,
         "y" : 329
       }, {
-        "id" : "53",
-        "x" : 4179,
-        "y" : 1629
-      }, {
         "id" : "10",
         "x" : 329,
         "y" : 329
       } ],
       "relationships" : [ {
-        "id" : "50",
+        "id" : "60"
+      }, {
+        "id" : "51",
         "vertices" : [ {
           "x" : 879,
           "y" : 833
         } ]
       }, {
-        "id" : "71"
-      }, {
-        "id" : "60"
-      }, {
-        "id" : "40"
-      }, {
-        "id" : "52",
-        "vertices" : [ {
-          "x" : 3650,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "42"
-      }, {
-        "id" : "32",
-        "vertices" : [ {
-          "x" : 7179,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "36",
-        "vertices" : [ {
-          "x" : 5779,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "34",
-        "vertices" : [ {
-          "x" : 6479,
-          "y" : 833
-        } ]
-      }, {
-        "id" : "44",
+        "id" : "42",
         "vertices" : [ {
           "x" : 2979,
           "y" : 833
         } ]
       }, {
-        "id" : "46",
+        "id" : "54",
+        "vertices" : [ {
+          "x" : 3650,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "30",
+        "vertices" : [ {
+          "x" : 5779,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "27",
+        "vertices" : [ {
+          "x" : 6479,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "36"
+      }, {
+        "id" : "24",
+        "vertices" : [ {
+          "x" : 7179,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "33",
+        "vertices" : [ {
+          "x" : 5079,
+          "y" : 833
+        } ]
+      }, {
+        "id" : "45",
         "vertices" : [ {
           "x" : 2279,
           "y" : 833
@@ -839,44 +718,11 @@
           "y" : 833
         } ]
       }, {
-        "id" : "38",
-        "vertices" : [ {
-          "x" : 5079,
-          "y" : 833
-        } ]
-      } ]
-    }, {
-      "softwareSystemId" : "28",
-      "key" : "DatabaseofQualifiedTeachersDQT-SystemContext",
-      "paperSize" : "A6_Portrait",
-      "dimensions" : {
-        "width" : 866,
-        "height" : 1316
-      },
-      "automaticLayout" : {
-        "implementation" : "Graphviz",
-        "rankDirection" : "TopBottom",
-        "rankSeparation" : 300,
-        "nodeSeparation" : 300,
-        "edgeSeparation" : 0,
-        "vertices" : false
-      },
-      "enterpriseBoundaryVisible" : true,
-      "elements" : [ {
-        "id" : "12",
-        "x" : 208,
-        "y" : 208
-      }, {
-        "id" : "28",
-        "x" : 208,
-        "y" : 808
-      } ],
-      "relationships" : [ {
-        "id" : "71"
+        "id" : "39"
       } ]
     } ],
     "containerViews" : [ {
-      "softwareSystemId" : "28",
+      "softwareSystemId" : "19",
       "key" : "DatabaseofQualifiedTeachersDQT-Container",
       "paperSize" : "A5_Portrait",
       "dimensions" : {
@@ -897,18 +743,18 @@
         "x" : 329,
         "y" : 208
       }, {
-        "id" : "29",
+        "id" : "20",
         "x" : 329,
         "y" : 808
       }, {
-        "id" : "30",
+        "id" : "21",
         "x" : 329,
         "y" : 1408
       } ],
       "relationships" : [ {
-        "id" : "70"
+        "id" : "61"
       }, {
-        "id" : "72"
+        "id" : "59"
       } ]
     }, {
       "softwareSystemId" : "12",
@@ -916,7 +762,7 @@
       "paperSize" : "A1_Landscape",
       "dimensions" : {
         "width" : 7816,
-        "height" : 3320
+        "height" : 2016
       },
       "automaticLayout" : {
         "implementation" : "Graphviz",
@@ -929,154 +775,121 @@
       "externalSoftwareSystemBoundariesVisible" : true,
       "elements" : [ {
         "id" : "11",
-        "x" : 207,
-        "y" : 213
+        "x" : 208,
+        "y" : 208
       }, {
         "id" : "13",
-        "x" : 3682,
-        "y" : 913
-      }, {
-        "id" : "24",
-        "x" : 3836,
-        "y" : 1513
-      }, {
-        "id" : "28",
-        "x" : 4495,
-        "y" : 2713
-      }, {
-        "id" : "18",
-        "x" : 3745,
-        "y" : 2713
+        "x" : 3683,
+        "y" : 908
       }, {
         "id" : "19",
-        "x" : 3745,
-        "y" : 2113
+        "x" : 3683,
+        "y" : 1508
       }, {
         "id" : "1",
-        "x" : 907,
-        "y" : 213
+        "x" : 908,
+        "y" : 208
       }, {
         "id" : "2",
-        "x" : 1607,
-        "y" : 213
+        "x" : 1608,
+        "y" : 208
       }, {
         "id" : "3",
-        "x" : 2307,
-        "y" : 213
+        "x" : 2308,
+        "y" : 208
       }, {
         "id" : "4",
-        "x" : 3007,
-        "y" : 213
+        "x" : 3008,
+        "y" : 208
       }, {
         "id" : "5",
-        "x" : 3707,
-        "y" : 213
+        "x" : 3708,
+        "y" : 208
       }, {
         "id" : "6",
-        "x" : 4407,
-        "y" : 213
+        "x" : 4408,
+        "y" : 208
       }, {
         "id" : "7",
-        "x" : 5107,
-        "y" : 213
+        "x" : 5108,
+        "y" : 208
       }, {
         "id" : "8",
-        "x" : 5807,
-        "y" : 213
+        "x" : 5808,
+        "y" : 208
       }, {
         "id" : "9",
-        "x" : 6507,
-        "y" : 213
-      }, {
-        "id" : "53",
-        "x" : 4495,
-        "y" : 2113
+        "x" : 6508,
+        "y" : 208
       }, {
         "id" : "10",
-        "x" : 7207,
-        "y" : 213
+        "x" : 7208,
+        "y" : 208
       } ],
       "relationships" : [ {
-        "id" : "51",
+        "id" : "50",
         "vertices" : [ {
-          "x" : 757,
-          "y" : 613
+          "x" : 7058,
+          "y" : 608
         } ]
       }, {
-        "id" : "41"
-      }, {
-        "id" : "62"
-      }, {
-        "id" : "65"
-      }, {
-        "id" : "43",
+        "id" : "41",
         "vertices" : [ {
-          "x" : 4957,
-          "y" : 613
+          "x" : 4958,
+          "y" : 608
         } ]
       }, {
-        "id" : "31",
+        "id" : "53",
         "vertices" : [ {
-          "x" : 1457,
-          "y" : 613
+          "x" : 758,
+          "y" : 608
         } ]
       }, {
-        "id" : "37"
+        "id" : "32"
       }, {
-        "id" : "35",
+        "id" : "29",
         "vertices" : [ {
-          "x" : 2857,
-          "y" : 613
+          "x" : 2858,
+          "y" : 608
         } ]
       }, {
-        "id" : "33",
+        "id" : "26",
         "vertices" : [ {
-          "x" : 2157,
-          "y" : 613
+          "x" : 2158,
+          "y" : 608
         } ]
       }, {
-        "id" : "77",
+        "id" : "35"
+      }, {
+        "id" : "23",
         "vertices" : [ {
-          "x" : 3686,
-          "y" : 1513
-        }, {
-          "x" : 3686,
-          "y" : 1813
+          "x" : 1458,
+          "y" : 608
         } ]
       }, {
-        "id" : "45",
+        "id" : "44",
         "vertices" : [ {
-          "x" : 5657,
-          "y" : 613
+          "x" : 5658,
+          "y" : 608
         } ]
-      }, {
-        "id" : "69"
-      }, {
-        "id" : "57"
       }, {
         "id" : "47",
         "vertices" : [ {
-          "x" : 6357,
-          "y" : 613
+          "x" : 6358,
+          "y" : 608
         } ]
       }, {
-        "id" : "59"
+        "id" : "58"
       }, {
-        "id" : "49",
-        "vertices" : [ {
-          "x" : 7057,
-          "y" : 613
-        } ]
-      }, {
-        "id" : "39"
+        "id" : "38"
       } ]
     } ],
     "componentViews" : [ {
       "key" : "TeacherIdentityService-TeacherIdentityWebApplication-Component",
-      "paperSize" : "A4_Landscape",
+      "paperSize" : "A1_Landscape",
       "dimensions" : {
-        "width" : 3162,
-        "height" : 2054
+        "width" : 7816,
+        "height" : 3216
       },
       "automaticLayout" : {
         "implementation" : "Graphviz",
@@ -1089,162 +902,138 @@
       "containerId" : "13",
       "externalContainerBoundariesVisible" : true,
       "elements" : [ {
-        "id" : "24",
-        "x" : 2487,
-        "y" : 929
+        "id" : "11",
+        "x" : 207,
+        "y" : 207
       }, {
         "id" : "14",
-        "x" : 1079,
-        "y" : 329
+        "x" : 3682,
+        "y" : 907
       }, {
         "id" : "15",
-        "x" : 1079,
-        "y" : 929
+        "x" : 3307,
+        "y" : 1507
       }, {
         "id" : "16",
-        "x" : 1829,
-        "y" : 329
+        "x" : 3307,
+        "y" : 2107
       }, {
         "id" : "17",
-        "x" : 329,
-        "y" : 329
-      }, {
-        "id" : "19",
-        "x" : 2133,
-        "y" : 1529
-      } ],
-      "relationships" : [ {
-        "id" : "62"
-      }, {
-        "id" : "76"
-      }, {
-        "id" : "75"
-      }, {
-        "id" : "55"
-      } ]
-    }, {
-      "key" : "TeacherIdentityService-IdentityDataBrokerAPI-Component",
-      "paperSize" : "A4_Portrait",
-      "dimensions" : {
-        "width" : 1858,
-        "height" : 2516
-      },
-      "automaticLayout" : {
-        "implementation" : "Graphviz",
-        "rankDirection" : "TopBottom",
-        "rankSeparation" : 300,
-        "nodeSeparation" : 300,
-        "edgeSeparation" : 0,
-        "vertices" : false
-      },
-      "containerId" : "19",
-      "externalContainerBoundariesVisible" : true,
-      "elements" : [ {
-        "id" : "22",
-        "x" : 329,
-        "y" : 1408
-      }, {
-        "id" : "23",
-        "x" : 1079,
-        "y" : 1408
-      }, {
-        "id" : "13",
-        "x" : 329,
-        "y" : 208
-      }, {
-        "id" : "28",
-        "x" : 1079,
-        "y" : 2008
+        "x" : 4057,
+        "y" : 1507
       }, {
         "id" : "18",
-        "x" : 329,
-        "y" : 2008
+        "x" : 4057,
+        "y" : 2107
       }, {
-        "id" : "20",
-        "x" : 329,
-        "y" : 808
+        "id" : "19",
+        "x" : 4057,
+        "y" : 2707
       }, {
-        "id" : "21",
-        "x" : 1079,
-        "y" : 808
+        "id" : "1",
+        "x" : 907,
+        "y" : 207
+      }, {
+        "id" : "2",
+        "x" : 1607,
+        "y" : 207
+      }, {
+        "id" : "3",
+        "x" : 2307,
+        "y" : 207
+      }, {
+        "id" : "4",
+        "x" : 3007,
+        "y" : 207
+      }, {
+        "id" : "5",
+        "x" : 3707,
+        "y" : 207
+      }, {
+        "id" : "6",
+        "x" : 4407,
+        "y" : 207
+      }, {
+        "id" : "7",
+        "x" : 5107,
+        "y" : 207
+      }, {
+        "id" : "8",
+        "x" : 5807,
+        "y" : 207
+      }, {
+        "id" : "9",
+        "x" : 6507,
+        "y" : 207
+      }, {
+        "id" : "10",
+        "x" : 7207,
+        "y" : 207
       } ],
       "relationships" : [ {
-        "id" : "82"
+        "id" : "63"
       }, {
-        "id" : "80"
+        "id" : "40",
+        "vertices" : [ {
+          "x" : 4957,
+          "y" : 607
+        } ]
+      }, {
+        "id" : "62"
+      }, {
+        "id" : "52",
+        "vertices" : [ {
+          "x" : 757,
+          "y" : 607
+        } ]
+      }, {
+        "id" : "65"
       }, {
         "id" : "64"
       }, {
-        "id" : "78"
+        "id" : "43",
+        "vertices" : [ {
+          "x" : 5657,
+          "y" : 607
+        } ]
       }, {
-        "id" : "67"
+        "id" : "31"
       }, {
-        "id" : "79"
-      } ]
-    }, {
-      "key" : "TeacherIdentityService-GOVUKIntegrationService-Component",
-      "paperSize" : "A4_Landscape",
-      "dimensions" : {
-        "width" : 3254,
-        "height" : 2020
-      },
-      "automaticLayout" : {
-        "implementation" : "Graphviz",
-        "rankDirection" : "TopBottom",
-        "rankSeparation" : 300,
-        "nodeSeparation" : 300,
-        "edgeSeparation" : 0,
-        "vertices" : false
-      },
-      "containerId" : "24",
-      "externalContainerBoundariesVisible" : true,
-      "elements" : [ {
-        "id" : "13",
-        "x" : 1416,
-        "y" : 208
+        "id" : "28",
+        "vertices" : [ {
+          "x" : 2857,
+          "y" : 607
+        } ]
+      }, {
+        "id" : "37"
       }, {
         "id" : "25",
-        "x" : 1079,
-        "y" : 808
-      }, {
-        "id" : "26",
-        "x" : 329,
-        "y" : 1408
-      }, {
-        "id" : "27",
-        "x" : 1079,
-        "y" : 1408
-      }, {
-        "id" : "19",
-        "x" : 2579,
-        "y" : 1408
-      }, {
-        "id" : "53",
-        "x" : 1829,
-        "y" : 1408
-      } ],
-      "relationships" : [ {
-        "id" : "61",
         "vertices" : [ {
-          "x" : 1998,
-          "y" : 1397
+          "x" : 2157,
+          "y" : 607
         } ]
       }, {
-        "id" : "74"
+        "id" : "34"
       }, {
-        "id" : "63",
+        "id" : "22",
         "vertices" : [ {
-          "x" : 2109,
-          "y" : 1118
+          "x" : 1457,
+          "y" : 607
         } ]
-      }, {
-        "id" : "73"
       }, {
         "id" : "56"
       }, {
-        "id" : "77"
+        "id" : "46",
+        "vertices" : [ {
+          "x" : 6357,
+          "y" : 607
+        } ]
       }, {
-        "id" : "58"
+        "id" : "49",
+        "vertices" : [ {
+          "x" : 7057,
+          "y" : 607
+        } ]
       } ]
     } ],
     "configuration" : {
@@ -1252,7 +1041,7 @@
       "styles" : { },
       "themes" : [ "https://static.structurizr.com/themes/default/theme.json" ],
       "terminology" : { },
-      "lastSavedView" : "TeacherIdentityService-GOVUKIntegrationService-Component"
+      "lastSavedView" : "TeacherIdentityService-TeacherIdentityWebApplication-Component"
     }
   }
 }


### PR DESCRIPTION
# Update to C4 Diagram to remove Broker API

This update removes the Broker API from the architecture, in place of a direct connection between the FindMyTRN app and the DQT API.  As a result, the GOV.UK Account interactions that were present are also removed.

More detail is also added to the FindMyTRN Web app.