### PR TITLE
GOV.UK PaaS ADR

### DIFF
--- a/docs/architecture/decisions/0002-use-gov-paas.md
+++ b/docs/architecture/decisions/0002-use-gov-paas.md
@@ -1,0 +1,22 @@
+# 1. Record architecture decisions
+
+Date: 2021-12-13
+
+## Status
+
+Accepted
+
+## Context
+
+We have two main hosting options for the Find My TRN service - GOV PaaS, or Azure CIP
+
+## Decision
+
+We will use the GOV PaaS platform to host the Find My TRN web application
+
+## Consequences
+
+* Cloud services are limited to that which are available on the GOV PaaS Platform
+* Cloudfoundry to be used to operate platform
+* AWS Shield ingress protection
+* 24/7 Support available


### PR DESCRIPTION
# ADR Record for GOV.UK PaaS decision
The Find My TRN application will be hosted on GOV.UK PaaS, and this PR encapsulates that decision.